### PR TITLE
Respect lock-file and add update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,24 @@ All command line flags:
 [embedmd]:# (_output/help.txt)
 ```txt
 $ jb -h
-Usage of jb:
-  -jsonnetpkg-home string
-    	The directory used to cache packages in. (default "vendor")
+usage: jb [<flags>] <command> [<args> ...]
+
+A jsonnet package manager
+
+Flags:
+  -h, --help  Show context-sensitive help (also try --help-long and --help-man).
+      --jsonnetpkg-home="vendor"  
+              The directory used to cache packages in.
+
+Commands:
+  help [<command>...]
+    Show help.
+
+  init
+    Initialize a new empty jsonnetfile
+
+  install [<packages>...]
+    Install all dependencies or install specific ones
+
+
 ```

--- a/README.md
+++ b/README.md
@@ -36,5 +36,8 @@ Commands:
   install [<packages>...]
     Install all dependencies or install specific ones
 
+  update
+    Update all dependencies.
+
 
 ```

--- a/pkg/packages_test.go
+++ b/pkg/packages_test.go
@@ -12,24 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package spec
+package pkg
 
-type JsonnetFile struct {
-	Dependencies []Dependency `json:"dependencies"`
-}
+import (
+	"testing"
 
-type Source struct {
-	GitSource *GitSource `json:"git"`
-}
+	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
+)
 
-type GitSource struct {
-	Remote string `json:"remote"`
-	Subdir string `json:"subdir"`
-}
+func TestInsert(t *testing.T) {
+	deps := []*spec.Dependency{&spec.Dependency{Name: "test1", Version: "latest"}}
+	dep := &spec.Dependency{Name: "test2", Version: "latest"}
 
-type Dependency struct {
-	Name      string `json:"name"`
-	Source    Source `json:"source"`
-	Version   string `json:"version"`
-	DepSource string `json:"-"`
+	res, err := insertDependency(deps, dep)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res) != 2 {
+		t.Fatal("Incorrectly inserted")
+	}
 }


### PR DESCRIPTION
This pull request fixes lock files to be generated correctly and that when a lock-file exists the given already resolved versions are used instead of always installing the "latest" version of the specified version. As this was often (mis-)used to update dependencies I have also added the `update` subcommand, which is purely to update all dependencies.

@metalmatze @tomwilkie 