### PR TITLE
Check for existing jsonnetfile.json before init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build:
 
 install: build
 	@$(eval OUTPUT=$(OUT_DIR)/$(GOOS)/$(GOARCH)/$(BIN))
-	@echo ">> copying $(BIN) into $(GOPATH)/$(BIN)"
+	@echo ">> copying $(BIN) into $(GOPATH)/bin/$(BIN)"
 	@cp $(OUTPUT) $(GOPATH)/bin/$(BIN)
 
 test:

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -101,9 +101,19 @@ func Main() int {
 }
 
 func initCommand() int {
-	err := ioutil.WriteFile(pkg.JsonnetFile, []byte("{}"), 0644)
+	exists, err := pkg.FileExists(pkg.JsonnetFile)
 	if err != nil {
-		kingpin.Fatalf("Failed to write new jsonnetfile.json: %v", err)
+		kingpin.Errorf("Failed to check for jsonnetfile.json: %v", err)
+		return 1
+	}
+
+	if exists {
+		kingpin.Errorf("jsonnetfile.json already exists")
+		return 1
+	}
+
+	if err := ioutil.WriteFile(pkg.JsonnetFile, []byte("{}"), 0644); err != nil {
+		kingpin.Errorf("Failed to write new jsonnetfile.json: %v", err)
 		return 1
 	}
 

--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -147,9 +147,8 @@ func insertDependency(deps []spec.Dependency, newDep spec.Dependency) ([]spec.De
 	return res, nil
 }
 
-func LockExists(dir string) (bool, error) {
-	lockfile := path.Join(dir, JsonnetLockFile)
-	_, err := os.Stat(lockfile)
+func FileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return false, nil
 	}
@@ -166,7 +165,7 @@ func ChooseJsonnetFile(dir string) (string, bool, error) {
 	filename := lockfile
 	isLock := true
 
-	lockExists, err := LockExists(dir)
+	lockExists, err := FileExists(filepath.Join(dir, JsonnetLockFile))
 	if err != nil {
 		return "", false, err
 	}


### PR DESCRIPTION
If a `jsonnetfile.json` in the current directory already exists we won't initialize a new one. 

Fixes #3 