### PR TITLE
Add a newline at the end of jsonnetfile

### DIFF
--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -112,7 +112,7 @@ func initCommand() int {
 		return 1
 	}
 
-	if err := ioutil.WriteFile(pkg.JsonnetFile, []byte("{}"), 0644); err != nil {
+	if err := ioutil.WriteFile(pkg.JsonnetFile, []byte("{}\n"), 0644); err != nil {
 		kingpin.Errorf("Failed to write new jsonnetfile.json: %v", err)
 		return 1
 	}
@@ -305,6 +305,7 @@ func installCommand(jsonnetHome string, urls ...*url.URL) int {
 			kingpin.Fatalf("failed to encode jsonnet file: %v", err)
 			return 3
 		}
+		b = append(b, []byte("\n")...)
 
 		err = ioutil.WriteFile(pkg.JsonnetFile, b, 0644)
 		if err != nil {
@@ -317,6 +318,7 @@ func installCommand(jsonnetHome string, urls ...*url.URL) int {
 			kingpin.Fatalf("failed to encode jsonnet file: %v", err)
 			return 3
 		}
+		b = append(b, []byte("\n")...)
 
 		err = ioutil.WriteFile(pkg.JsonnetLockFile, b, 0644)
 		if err != nil {
@@ -356,6 +358,7 @@ func updateCommand(jsonnetHome string, urls ...*url.URL) int {
 		kingpin.Fatalf("failed to encode jsonnet file: %v", err)
 		return 3
 	}
+	b = append(b, []byte("\n")...)
 
 	err = ioutil.WriteFile(pkg.JsonnetLockFile, b, 0644)
 	if err != nil {


### PR DESCRIPTION
Always add a newline at the end of `jsonnetfile.json` and `jsonnetfile.lock.json` making diffs a bit nicer. 
Current situation can be seen here: https://github.com/coreos/prometheus-operator/commit/ca93f987b9cb392654f07eaf1a455c054c451fa5#diff-88fe225f23f7d800f3c1d43af3ae198aR84