### PR TITLE
Add local dependencies as source dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ install: build
 
 test:
 	@echo ">> running all unit tests"
-	@go test $(PKGS)
+	go test -v $(PKGS)
 
 test-integration:
 	@echo ">> running all integration tests"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Commands:
   init
     Initialize a new empty jsonnetfile
 
-  install [<packages>...]
+  install [<paths>...]
     Install all dependencies or install specific ones
 
   update

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Commands:
   init
     Initialize a new empty jsonnetfile
 
-  install [<paths>...]
+  install [<uris>...]
     Install all dependencies or install specific ones
 
   update

--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -46,7 +46,7 @@ func installCommand(dir, jsonnetHome string, paths ...string) int {
 
 	if len(paths) > 0 {
 		for _, path := range paths {
-			newDep := parseDependency(path)
+			newDep := parseDependency(dir, path)
 			if newDep == nil {
 				kingpin.Errorf("ignoring unrecognized path: %s", path)
 				continue

--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -27,7 +27,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-func installCommand(dir, jsonnetHome string, paths ...string) int {
+func installCommand(dir, jsonnetHome string, uris ...string) int {
 	if dir == "" {
 		dir = "."
 	}
@@ -44,11 +44,11 @@ func installCommand(dir, jsonnetHome string, paths ...string) int {
 		return 1
 	}
 
-	if len(paths) > 0 {
-		for _, path := range paths {
-			newDep := parseDependency(dir, path)
+	if len(uris) > 0 {
+		for _, uri := range uris {
+			newDep := parseDependency(dir, uri)
 			if newDep == nil {
-				kingpin.Errorf("ignoring unrecognized path: %s", path)
+				kingpin.Errorf("ignoring unrecognized uri: %s", uri)
 				continue
 			}
 

--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -46,14 +46,7 @@ func installCommand(dir, jsonnetHome string, paths ...string) int {
 
 	if len(paths) > 0 {
 		for _, path := range paths {
-			// install package specified in command
-			// $ jsonnetpkg install ksonnet git@github.com:ksonnet/ksonnet-lib
-			// $ jsonnetpkg install grafonnet git@github.com:grafana/grafonnet-lib grafonnet
-			// $ jsonnetpkg install github.com/grafana/grafonnet-lib/grafonnet
-			//
-			// github.com/(slug)/(dir)
-
-			newDep := parseDepedency(path)
+			newDep := parseDependency(path)
 			if newDep == nil {
 				kingpin.Errorf("ignoring unrecognized path: %s", path)
 				continue

--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path/filepath"
 
@@ -28,7 +27,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-func installCommand(dir, jsonnetHome string, urls ...*url.URL) int {
+func installCommand(dir, jsonnetHome string, paths ...string) int {
 	if dir == "" {
 		dir = "."
 	}
@@ -45,8 +44,8 @@ func installCommand(dir, jsonnetHome string, urls ...*url.URL) int {
 		return 1
 	}
 
-	if len(urls) > 0 {
-		for _, url := range urls {
+	if len(paths) > 0 {
+		for _, path := range paths {
 			// install package specified in command
 			// $ jsonnetpkg install ksonnet git@github.com:ksonnet/ksonnet-lib
 			// $ jsonnetpkg install grafonnet git@github.com:grafana/grafonnet-lib grafonnet
@@ -54,10 +53,9 @@ func installCommand(dir, jsonnetHome string, urls ...*url.URL) int {
 			//
 			// github.com/(slug)/(dir)
 
-			urlString := url.String()
-			newDep := parseDepedency(urlString)
+			newDep := parseDepedency(path)
 			if newDep == nil {
-				kingpin.Errorf("ignoring unrecognized url: %s", url)
+				kingpin.Errorf("ignoring unrecognized path: %s", path)
 				continue
 			}
 

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -40,26 +40,28 @@ func TestInstallCommand(t *testing.T) {
 			ExpectedJsonnetFile:     []byte(`{"dependencies":null}`),
 			ExpectedJsonnetLockFile: []byte(`{"dependencies":null}`),
 		}, {
-			Name: "OneURL",
-			URLs: []*url.URL{
-				{
-					Scheme: "https",
-					Host:   "github.com",
-					Path:   "jsonnet-bundler/jsonnet-bundler@v0.1.0",
-				},
-			},
+			Name:                    "OneURL",
+			URLs:                    []string{"github.com/jsonnet-bundler/jsonnet-bundler@v0.1.0"},
 			ExpectedCode:            0,
 			ExpectedJsonnetFile:     []byte(`{"dependencies": [{"name": "jsonnet-bundler", "source": {"git": {"remote": "https://github.com/jsonnet-bundler/jsonnet-bundler", "subdir": ""}}, "version": "v0.1.0"}]}`),
 			ExpectedJsonnetLockFile: []byte(`{"dependencies": [{"name": "jsonnet-bundler", "source": {"git": {"remote": "https://github.com/jsonnet-bundler/jsonnet-bundler", "subdir": ""}}, "version": "080f157c7fb85ad0281ea78f6c641eaa570a582f"}]}`),
+		}, {
+			Name:                    "Relative",
+			URLs:                    []string{"test/jsonnet/foobar"},
+			ExpectedCode:            0,
+			ExpectedJsonnetFile:     []byte(`{"dependencies":null}`),
+			ExpectedJsonnetLockFile: []byte(`{"dependencies":null}`),
 		},
 	}
 
 	for _, tc := range testcases {
-		t.Run(tc.Name, func(t *testing.T) {
+		_ = t.Run(tc.Name, func(t *testing.T) {
 			tempDir, err := ioutil.TempDir("", "jb-install")
 			assert.NoError(t, err)
+			err = os.MkdirAll(filepath.Join(tempDir, "test/jsonnet/foobar"), os.ModePerm)
+			assert.NoError(t, err)
 			defer os.Remove(tempDir)
-			defer os.RemoveAll("vendor") // delete test vendor folder
+			defer os.RemoveAll("vendor") // cloning jsonnet-bundler will create this folder
 
 			jsonnetFile := filepath.Join(tempDir, jsonnetfile.File)
 			jsonnetLockFile := filepath.Join(tempDir, jsonnetfile.LockFile)

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -29,7 +29,7 @@ import (
 func TestInstallCommand(t *testing.T) {
 	testcases := []struct {
 		Name                    string
-		URLs                    []string
+		URIs                    []string
 		ExpectedCode            int
 		ExpectedJsonnetFile     []byte
 		ExpectedJsonnetLockFile []byte
@@ -41,13 +41,13 @@ func TestInstallCommand(t *testing.T) {
 			ExpectedJsonnetLockFile: []byte(`{"dependencies":null}`),
 		}, {
 			Name:                    "OneURL",
-			URLs:                    []string{"github.com/jsonnet-bundler/jsonnet-bundler@v0.1.0"},
+			URIs:                    []string{"github.com/jsonnet-bundler/jsonnet-bundler@v0.1.0"},
 			ExpectedCode:            0,
 			ExpectedJsonnetFile:     []byte(`{"dependencies": [{"name": "jsonnet-bundler", "source": {"git": {"remote": "https://github.com/jsonnet-bundler/jsonnet-bundler", "subdir": ""}}, "version": "v0.1.0"}]}`),
 			ExpectedJsonnetLockFile: []byte(`{"dependencies": [{"name": "jsonnet-bundler", "source": {"git": {"remote": "https://github.com/jsonnet-bundler/jsonnet-bundler", "subdir": ""}}, "version": "080f157c7fb85ad0281ea78f6c641eaa570a582f"}]}`),
 		}, {
 			Name:                    "Relative",
-			URLs:                    []string{"test/jsonnet/foobar"},
+			URIs:                    []string{"test/jsonnet/foobar"},
 			ExpectedCode:            0,
 			ExpectedJsonnetFile:     []byte(`{"dependencies": [{"name": "foobar", "source": {"local": {"directory": "test/jsonnet/foobar"}}, "version": ""}]}`),
 			ExpectedJsonnetLockFile: []byte(`{"dependencies": [{"name": "foobar", "source": {"local": {"directory": "test/jsonnet/foobar"}}, "version": ""}]}`),
@@ -71,7 +71,7 @@ func TestInstallCommand(t *testing.T) {
 
 			jsonnetFileContent(t, jsonnetFile, []byte(`{}`))
 
-			code = installCommand(tempDir, "vendor", tc.URLs...)
+			code = installCommand(tempDir, "vendor", tc.URIs...)
 			assert.Equal(t, tc.ExpectedCode, code)
 
 			jsonnetFileContent(t, jsonnetFile, tc.ExpectedJsonnetFile)

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +29,7 @@ import (
 func TestInstallCommand(t *testing.T) {
 	testcases := []struct {
 		Name                    string
-		URLs                    []*url.URL
+		URLs                    []string
 		ExpectedCode            int
 		ExpectedJsonnetFile     []byte
 		ExpectedJsonnetLockFile []byte

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -49,8 +49,8 @@ func TestInstallCommand(t *testing.T) {
 			Name:                    "Relative",
 			URLs:                    []string{"test/jsonnet/foobar"},
 			ExpectedCode:            0,
-			ExpectedJsonnetFile:     []byte(`{"dependencies":null}`),
-			ExpectedJsonnetLockFile: []byte(`{"dependencies":null}`),
+			ExpectedJsonnetFile:     []byte(`{"dependencies": [{"name": "foobar", "source": {"local": {"directory": "test/jsonnet/foobar"}}, "version": ""}]}`),
+			ExpectedJsonnetLockFile: []byte(`{"dependencies": [{"name": "foobar", "source": {"local": {"directory": "test/jsonnet/foobar"}}, "version": ""}]}`),
 		},
 	}
 
@@ -81,6 +81,8 @@ func TestInstallCommand(t *testing.T) {
 }
 
 func jsonnetFileContent(t *testing.T, filename string, content []byte) {
+	t.Helper()
+
 	bytes, err := ioutil.ReadFile(filename)
 	assert.NoError(t, err)
 	if eq := assert.JSONEq(t, string(content), string(bytes)); !eq {

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -98,7 +98,7 @@ func Main() int {
 	return 0
 }
 
-func parseDepedency(urlString string) *spec.Dependency {
+func parseDependency(urlString string) *spec.Dependency {
 	if spec := parseGitSSHDependency(urlString); spec != nil {
 		return spec
 	}

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -226,8 +226,6 @@ func parseLocalDependency(p string) *spec.Dependency {
 
 	info, err := os.Stat(clean)
 	if err != nil {
-		wd, _ := os.Getwd()
-		fmt.Println(err, wd)
 		return nil
 	}
 
@@ -238,11 +236,10 @@ func parseLocalDependency(p string) *spec.Dependency {
 	return &spec.Dependency{
 		Name: info.Name(),
 		Source: spec.Source{
-			GitSource: &spec.GitSource{
-				Remote: ".",
-				Subdir: clean,
+			LocalSource: &spec.LocalSource{
+				Directory: clean,
 			},
 		},
-		Version: ".",
+		Version: "",
 	}
 }

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -63,7 +63,7 @@ func Main() int {
 	initCmd := a.Command(initActionName, "Initialize a new empty jsonnetfile")
 
 	installCmd := a.Command(installActionName, "Install all dependencies or install specific ones")
-	installCmdPaths := installCmd.Arg("paths", "paths to packages to install, URLs or file paths").Strings()
+	installCmdURIs := installCmd.Arg("uris", "URIs to packages to install, URLs or file paths").Strings()
 
 	updateCmd := a.Command(updateActionName, "Update all dependencies.")
 
@@ -83,7 +83,7 @@ func Main() int {
 	case initCmd.FullCommand():
 		return initCommand(workdir)
 	case installCmd.FullCommand():
-		return installCommand(workdir, cfg.JsonnetHome, *installCmdPaths...)
+		return installCommand(workdir, cfg.JsonnetHome, *installCmdURIs...)
 	case updateCmd.FullCommand():
 		return updateCommand(cfg.JsonnetHome)
 	default:
@@ -93,16 +93,16 @@ func Main() int {
 	return 0
 }
 
-func parseDependency(dir, path string) *spec.Dependency {
-	if d := parseGitSSHDependency(path); d != nil {
+func parseDependency(dir, uri string) *spec.Dependency {
+	if d := parseGitSSHDependency(uri); d != nil {
 		return d
 	}
 
-	if d := parseGithubDependency(path); d != nil {
+	if d := parseGithubDependency(uri); d != nil {
 		return d
 	}
 
-	if d := parseLocalDependency(dir, path); d != nil {
+	if d := parseLocalDependency(dir, uri); d != nil {
 		return d
 	}
 

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 
 	"github.com/jsonnet-bundler/jsonnet-bundler/pkg"
+	"github.com/jsonnet-bundler/jsonnet-bundler/pkg/jsonnetfile"
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
 	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -218,9 +219,7 @@ func parseGithubDependency(urlString string) *spec.Dependency {
 }
 
 func updateCommand(jsonnetHome string, urls ...*url.URL) int {
-	jsonnetfile := pkg.JsonnetFile
-
-	m, err := pkg.LoadJsonnetfile(jsonnetfile)
+	m, err := pkg.LoadJsonnetfile(jsonnetfile.File)
 	if err != nil {
 		kingpin.Fatalf("failed to load jsonnetfile: %v", err)
 		return 1
@@ -234,7 +233,7 @@ func updateCommand(jsonnetHome string, urls ...*url.URL) int {
 
 	// When updating, the lockfile is explicitly ignored.
 	isLock := false
-	lock, err := pkg.Install(context.TODO(), isLock, jsonnetfile, m, jsonnetHome)
+	lock, err := pkg.Install(context.TODO(), isLock, jsonnetfile.File, m, jsonnetHome)
 	if err != nil {
 		kingpin.Fatalf("failed to install: %v", err)
 		return 3
@@ -247,7 +246,7 @@ func updateCommand(jsonnetHome string, urls ...*url.URL) int {
 	}
 	b = append(b, []byte("\n")...)
 
-	err = ioutil.WriteFile(pkg.JsonnetLockFile, b, 0644)
+	err = ioutil.WriteFile(jsonnetfile.LockFile, b, 0644)
 	if err != nil {
 		kingpin.Fatalf("failed to write lock file: %v", err)
 		return 3

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -68,7 +68,7 @@ func Main() int {
 	initCmd := a.Command(initActionName, "Initialize a new empty jsonnetfile")
 
 	installCmd := a.Command(installActionName, "Install all dependencies or install specific ones")
-	installCmdURLs := installCmd.Arg("packages", "URLs to package to install").URLList()
+	installCmdPaths := installCmd.Arg("paths", "paths to packages to install, URLs or file paths").Strings()
 
 	updateCmd := a.Command(updateActionName, "Update all dependencies.")
 
@@ -88,7 +88,7 @@ func Main() int {
 	case initCmd.FullCommand():
 		return initCommand(workdir)
 	case installCmd.FullCommand():
-		return installCommand(workdir, cfg.JsonnetHome, *installCmdURLs...)
+		return installCommand(workdir, cfg.JsonnetHome, *installCmdPaths...)
 	case updateCmd.FullCommand():
 		return updateCommand(cfg.JsonnetHome)
 	default:

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -15,18 +15,12 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"regexp"
 
-	"github.com/jsonnet-bundler/jsonnet-bundler/pkg"
-	"github.com/jsonnet-bundler/jsonnet-bundler/pkg/jsonnetfile"
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
 	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -216,41 +210,4 @@ func parseGithubDependency(urlString string) *spec.Dependency {
 		},
 		Version: version,
 	}
-}
-
-func updateCommand(jsonnetHome string, urls ...*url.URL) int {
-	m, err := pkg.LoadJsonnetfile(jsonnetfile.File)
-	if err != nil {
-		kingpin.Fatalf("failed to load jsonnetfile: %v", err)
-		return 1
-	}
-
-	err = os.MkdirAll(jsonnetHome, os.ModePerm)
-	if err != nil {
-		kingpin.Fatalf("failed to create jsonnet home path: %v", err)
-		return 3
-	}
-
-	// When updating, the lockfile is explicitly ignored.
-	isLock := false
-	lock, err := pkg.Install(context.TODO(), isLock, jsonnetfile.File, m, jsonnetHome)
-	if err != nil {
-		kingpin.Fatalf("failed to install: %v", err)
-		return 3
-	}
-
-	b, err := json.MarshalIndent(lock, "", "    ")
-	if err != nil {
-		kingpin.Fatalf("failed to encode jsonnet file: %v", err)
-		return 3
-	}
-	b = append(b, []byte("\n")...)
-
-	err = ioutil.WriteFile(jsonnetfile.LockFile, b, 0644)
-	if err != nil {
-		kingpin.Fatalf("failed to write lock file: %v", err)
-		return 3
-	}
-
-	return 0
 }

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -93,7 +93,7 @@ func Main() int {
 	return 0
 }
 
-func parseDependency(path string) *spec.Dependency {
+func parseDependency(dir, path string) *spec.Dependency {
 	if d := parseGitSSHDependency(path); d != nil {
 		return d
 	}
@@ -102,7 +102,7 @@ func parseDependency(path string) *spec.Dependency {
 		return d
 	}
 
-	if d := parseLocalDependency(path); d != nil {
+	if d := parseLocalDependency(dir, path); d != nil {
 		return d
 	}
 
@@ -211,7 +211,7 @@ func parseGithubDependency(p string) *spec.Dependency {
 	}
 }
 
-func parseLocalDependency(p string) *spec.Dependency {
+func parseLocalDependency(dir, p string) *spec.Dependency {
 	if p == "" {
 		return nil
 	}
@@ -223,8 +223,9 @@ func parseLocalDependency(p string) *spec.Dependency {
 	}
 
 	clean := filepath.Clean(p)
+	abs := filepath.Join(dir, clean)
 
-	info, err := os.Stat(clean)
+	info, err := os.Stat(abs)
 	if err != nil {
 		return nil
 	}

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -30,15 +30,9 @@ const (
 	installActionName = "install"
 	updateActionName  = "update"
 	initActionName    = "init"
-	basePath          = ".jsonnetpkg"
-	srcDirName        = "src"
 )
 
 var (
-	availableSubcommands = []string{
-		initActionName,
-		installActionName,
-	}
 	gitSSHRegex                   = regexp.MustCompile("git\\+ssh://git@([^:]+):([^/]+)/([^/]+).git")
 	gitSSHWithVersionRegex        = regexp.MustCompile("git\\+ssh://git@([^:]+):([^/]+)/([^/]+).git@(.*)")
 	gitSSHWithPathRegex           = regexp.MustCompile("git\\+ssh://git@([^:]+):([^/]+)/([^/]+).git/(.*)")

--- a/cmd/jb/main_test.go
+++ b/cmd/jb/main_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseDepedency(t *testing.T) {
+func TestParseDependency(t *testing.T) {
 	const testFolder = "test/jsonnet/foobar"
 	err := os.MkdirAll(testFolder, os.ModePerm)
 	if err != nil {
@@ -79,12 +79,11 @@ func TestParseDepedency(t *testing.T) {
 			want: &spec.Dependency{
 				Name: "foobar",
 				Source: spec.Source{
-					GitSource: &spec.GitSource{
-						Remote: ".",
-						Subdir: "test/jsonnet/foobar",
+					LocalSource: &spec.LocalSource{
+						Directory: "test/jsonnet/foobar",
 					},
 				},
-				Version: ".",
+				Version: "",
 			},
 		},
 	}

--- a/cmd/jb/main_test.go
+++ b/cmd/jb/main_test.go
@@ -1,0 +1,80 @@
+// Copyright 2018 jsonnet-bundler authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDepedency(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want *spec.Dependency
+	}{
+		{
+			name: "Empty",
+			path: "",
+			want: nil,
+		},
+		{
+			name: "Invalid",
+			path: "github.com/foo",
+			want: nil,
+		},
+		{
+			name: "GitHub",
+			path: "github.com/jsonnet-bundler/jsonnet-bundler",
+			want: &spec.Dependency{
+				Name: "jsonnet-bundler",
+				Source: spec.Source{
+					GitSource: &spec.GitSource{
+						Remote: "https://github.com/jsonnet-bundler/jsonnet-bundler",
+						Subdir: "",
+					},
+				},
+				Version: "master",
+			},
+		},
+		{
+			name: "SSH",
+			path: "git+ssh://git@github.com:jsonnet-bundler/jsonnet-bundler.git",
+			want: &spec.Dependency{
+				Name: "jsonnet-bundler",
+				Source: spec.Source{
+					GitSource: &spec.GitSource{
+						Remote: "git@github.com:jsonnet-bundler/jsonnet-bundler",
+						Subdir: "",
+					},
+				},
+				Version: "master",
+			},
+		},
+	}
+	for _, tt := range tests {
+		_ = t.Run(tt.name, func(t *testing.T) {
+			dependency := parseDependency(tt.path)
+
+			if tt.path == "" {
+				assert.Nil(t, dependency)
+			} else {
+				assert.Equal(t, tt.want, dependency)
+			}
+		})
+	}
+}

--- a/cmd/jb/main_test.go
+++ b/cmd/jb/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
@@ -22,6 +23,13 @@ import (
 )
 
 func TestParseDepedency(t *testing.T) {
+	const testFolder = "test/jsonnet/foobar"
+	err := os.MkdirAll(testFolder, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll("test")
+
 	tests := []struct {
 		name string
 		path string
@@ -63,6 +71,20 @@ func TestParseDepedency(t *testing.T) {
 					},
 				},
 				Version: "master",
+			},
+		},
+		{
+			name: "local",
+			path: testFolder,
+			want: &spec.Dependency{
+				Name: "foobar",
+				Source: spec.Source{
+					GitSource: &spec.GitSource{
+						Remote: ".",
+						Subdir: "test/jsonnet/foobar",
+					},
+				},
+				Version: ".",
 			},
 		},
 	}

--- a/cmd/jb/main_test.go
+++ b/cmd/jb/main_test.go
@@ -89,7 +89,7 @@ func TestParseDependency(t *testing.T) {
 	}
 	for _, tt := range tests {
 		_ = t.Run(tt.name, func(t *testing.T) {
-			dependency := parseDependency(tt.path)
+			dependency := parseDependency("", tt.path)
 
 			if tt.path == "" {
 				assert.Nil(t, dependency)

--- a/cmd/jb/update.go
+++ b/cmd/jb/update.go
@@ -1,0 +1,64 @@
+// Copyright 2018 jsonnet-bundler authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/url"
+	"os"
+
+	"github.com/jsonnet-bundler/jsonnet-bundler/pkg"
+	"github.com/jsonnet-bundler/jsonnet-bundler/pkg/jsonnetfile"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func updateCommand(jsonnetHome string, urls ...*url.URL) int {
+	m, err := pkg.LoadJsonnetfile(jsonnetfile.File)
+	if err != nil {
+		kingpin.Fatalf("failed to load jsonnetfile: %v", err)
+		return 1
+	}
+
+	err = os.MkdirAll(jsonnetHome, os.ModePerm)
+	if err != nil {
+		kingpin.Fatalf("failed to create jsonnet home path: %v", err)
+		return 3
+	}
+
+	// When updating, the lockfile is explicitly ignored.
+	isLock := false
+	lock, err := pkg.Install(context.TODO(), isLock, jsonnetfile.File, m, jsonnetHome)
+	if err != nil {
+		kingpin.Fatalf("failed to install: %v", err)
+		return 3
+	}
+
+	b, err := json.MarshalIndent(lock, "", "    ")
+	if err != nil {
+		kingpin.Fatalf("failed to encode jsonnet file: %v", err)
+		return 3
+	}
+	b = append(b, []byte("\n")...)
+
+	err = ioutil.WriteFile(jsonnetfile.LockFile, b, 0644)
+	if err != nil {
+		kingpin.Fatalf("failed to write lock file: %v", err)
+		return 3
+	}
+
+	return 0
+}

--- a/pkg/interface.go
+++ b/pkg/interface.go
@@ -19,5 +19,5 @@ import (
 )
 
 type Interface interface {
-	Install(ctx context.Context, dir, version string) (lockVersion string, err error)
+	Install(ctx context.Context, name, dir, version string) (lockVersion string, err error)
 }

--- a/pkg/local.go
+++ b/pkg/local.go
@@ -12,29 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package spec
+package pkg
 
-type JsonnetFile struct {
-	Dependencies []Dependency `json:"dependencies"`
+import (
+	"context"
+	"fmt"
+
+	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
+)
+
+type LocalPackage struct {
+	Source *spec.LocalSource
 }
 
-type Dependency struct {
-	Name      string `json:"name"`
-	Source    Source `json:"source"`
-	Version   string `json:"version"`
-	DepSource string `json:"-"`
+func NewLocalPackage(source *spec.LocalSource) Interface {
+	return &LocalPackage{
+		Source: source,
+	}
 }
 
-type Source struct {
-	GitSource   *GitSource   `json:"git,omitempty"`
-	LocalSource *LocalSource `json:"local,omitempty"`
-}
+func (p *LocalPackage) Install(ctx context.Context, dir, version string) (lockVersion string, err error) {
+	fmt.Println("SYMLINK THIS SHIT, HAHA")
 
-type GitSource struct {
-	Remote string `json:"remote"`
-	Subdir string `json:"subdir"`
-}
+	// TODO: Where do I get the name of the package?
 
-type LocalSource struct {
-	Directory string `json:"directory"`
+	fmt.Println(ctx, dir, version)
+
+	return "", nil
 }

--- a/pkg/local.go
+++ b/pkg/local.go
@@ -17,6 +17,8 @@ package pkg
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
 )
@@ -31,12 +33,16 @@ func NewLocalPackage(source *spec.LocalSource) Interface {
 	}
 }
 
-func (p *LocalPackage) Install(ctx context.Context, dir, version string) (lockVersion string, err error) {
-	fmt.Println("SYMLINK THIS SHIT, HAHA")
+func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (lockVersion string, err error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current working directory: %v", err)
+	}
 
-	// TODO: Where do I get the name of the package?
-
-	fmt.Println(ctx, dir, version)
+	err = os.Symlink(filepath.Join(wd, p.Source.Directory), filepath.Join(wd, dir, name))
+	if err != nil {
+		return "", fmt.Errorf("failed to create symlink for local dependency: %v", err)
+	}
 
 	return "", nil
 }

--- a/pkg/local.go
+++ b/pkg/local.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
+	"github.com/pkg/errors"
 )
 
 type LocalPackage struct {
@@ -39,7 +40,14 @@ func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (
 		return "", fmt.Errorf("failed to get current working directory: %v", err)
 	}
 
-	err = os.Symlink(filepath.Join(wd, p.Source.Directory), filepath.Join(wd, dir, name))
+	destPath := filepath.Join(dir, name)
+
+	err = os.RemoveAll(destPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to clean previous destination path")
+	}
+
+	err = os.Symlink(filepath.Join(wd, p.Source.Directory), filepath.Join(wd, destPath))
 	if err != nil {
 		return "", fmt.Errorf("failed to create symlink for local dependency: %v", err)
 	}

--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -24,13 +24,12 @@ import (
 	"path/filepath"
 
 	"github.com/fatih/color"
+	"github.com/jsonnet-bundler/jsonnet-bundler/pkg/jsonnetfile"
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
 	"github.com/pkg/errors"
 )
 
 var (
-	JsonnetFile     = "jsonnetfile.json"
-	JsonnetLockFile = "jsonnetfile.lock.json"
 	VersionMismatch = errors.New("multiple colliding versions specified")
 )
 
@@ -161,18 +160,18 @@ func FileExists(path string) (bool, error) {
 }
 
 func ChooseJsonnetFile(dir string) (string, bool, error) {
-	lockfile := path.Join(dir, JsonnetLockFile)
-	jsonnetfile := path.Join(dir, JsonnetFile)
-	filename := lockfile
+	lockfilePath := path.Join(dir, jsonnetfile.LockFile)
+	jsonnetfilePath := path.Join(dir, jsonnetfile.File)
+	filename := lockfilePath
 	isLock := true
 
-	lockExists, err := FileExists(filepath.Join(dir, JsonnetLockFile))
+	lockExists, err := FileExists(filepath.Join(dir, jsonnetfile.LockFile))
 	if err != nil {
 		return "", false, err
 	}
 
 	if !lockExists {
-		filename = jsonnetfile
+		filename = jsonnetfilePath
 		isLock = false
 	}
 

--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -54,6 +54,9 @@ func Install(ctx context.Context, isLock bool, dependencySourceIdentifier string
 			p = NewGitPackage(dep.Source.GitSource)
 			subdir = dep.Source.GitSource.Subdir
 		}
+		if dep.Source.LocalSource != nil {
+			p = NewLocalPackage(dep.Source.LocalSource)
+		}
 
 		lockVersion, err := p.Install(ctx, tmpDir, dep.Version)
 		if err != nil {
@@ -100,7 +103,7 @@ func Install(ctx context.Context, isLock bool, dependencySourceIdentifier string
 			return nil, err
 		}
 		depsDeps, err := LoadJsonnetfile(filepath)
-		// It is ok for depedencies not to have a JsonnetFile, it just means
+		// It is ok for dependencies not to have a JsonnetFile, it just means
 		// they do not have transitive dependencies of their own.
 		if err != nil && !os.IsNotExist(err) {
 			return nil, err

--- a/pkg/packages_test.go
+++ b/pkg/packages_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/jsonnet-bundler/jsonnet-bundler/pkg/jsonnetfile"
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
 	"github.com/stretchr/testify/assert"
 )
@@ -110,7 +111,7 @@ func TestLoadJsonnetfile(t *testing.T) {
 			assert.Nil(t, err)
 		}()
 
-		tempFile := filepath.Join(tempDir, JsonnetFile)
+		tempFile := filepath.Join(tempDir, jsonnetfile.File)
 		err = ioutil.WriteFile(tempFile, []byte(`{}`), os.ModePerm)
 		assert.Nil(t, err)
 
@@ -128,7 +129,7 @@ func TestLoadJsonnetfile(t *testing.T) {
 			assert.Nil(t, err)
 		}()
 
-		tempFile := filepath.Join(tempDir, JsonnetFile)
+		tempFile := filepath.Join(tempDir, jsonnetfile.File)
 		err = ioutil.WriteFile(tempFile, []byte(jsonnetfileContent), os.ModePerm)
 		assert.Nil(t, err)
 

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -18,6 +18,13 @@ type JsonnetFile struct {
 	Dependencies []Dependency `json:"dependencies"`
 }
 
+type Dependency struct {
+	Name      string `json:"name"`
+	Source    Source `json:"source"`
+	Version   string `json:"version"`
+	DepSource string `json:"-"`
+}
+
 type Source struct {
 	GitSource *GitSource `json:"git"`
 }
@@ -25,11 +32,4 @@ type Source struct {
 type GitSource struct {
 	Remote string `json:"remote"`
 	Subdir string `json:"subdir"`
-}
-
-type Dependency struct {
-	Name      string `json:"name"`
-	Source    Source `json:"source"`
-	Version   string `json:"version"`
-	DepSource string `json:"-"`
 }


### PR DESCRIPTION
This adds local source dependencies as which will create a symlink inside the `vendor` folder to the actual folder on this. These change will make it obsolete to commit changes first, then run `jb update` and then generate new files.

Here is an example from kube-prometheus.

jsonnetfile.json:
```json
{
    "dependencies": [
        {
            "name": "kube-prometheus",
            "source": {
                "local": {
                    "directory": "jsonnet/kube-prometheus"
                }
            },
            "version": ""
        }
    ]
}
``` 
jsonnetfile.lock.json:
```json
{
    "dependencies": [
        {
            "name": "kube-prometheus",
            "source": {
                "local": {
                    "directory": "jsonnet/kube-prometheus"
                }
            },
            "version": ""
        },
        ...
    ]
}
```

/cc @brancz @squat @paulfantom @lilic @s-urbaniak @kakkoyun 