### PR TITLE
Git package install optimizations

### DIFF
--- a/pkg/git.go
+++ b/pkg/git.go
@@ -212,7 +212,7 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		}
 	}
 
-	// Sparse checkout optimization: if a Subdir is specificied,
+	// Sparse checkout optimization: if a Subdir is specified,
 	// there is no need to do a full checkout
 	if p.Source.Subdir != "" {
 		cmd = exec.CommandContext(ctx, "git", "config", "core.sparsecheckout", "true")
@@ -224,8 +224,12 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		if err != nil {
 			return "", err
 		}
+
 		glob := []byte(p.Source.Subdir + "/*\n")
-		ioutil.WriteFile(tmpDir+"/.git/info/sparse-checkout", glob, 0644)
+		err = ioutil.WriteFile(filepath.Join(tmpDir, ".git", "info", "sparse-checkout"), glob, 0644)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "-c", "advice.detachedHead=false", "checkout", version)

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -180,7 +180,14 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 			r, err := os.Open(archiveFilepath)
 			defer r.Close()
 			if err == nil {
+				// Extract the sub-directory (if any) from the archive
+				// If none specified, the entire archive is unpacked
 				err = gzipUntar(tmpDir, r, p.Source.Subdir)
+
+				// Move the extracted directory to its final destination
+				if err == nil {
+					err = os.Rename(path.Join(tmpDir, p.Source.Subdir), destPath)
+				}
 			}
 		}
 

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -162,7 +162,8 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 	// Optimization for GitHub sources: download a tarball archive of the requested
 	// version instead of cloning the entire repository. Resolves the version to a
 	// commit SHA using the GitHub API.
-	if strings.HasPrefix(p.Source.Remote, "https://github.com/") {
+	isGitHubRemote, err := regexp.MatchString(`^(https|ssh)://github\.com/.+$`, p.Source.Remote)
+	if isGitHubRemote {
 		archiveUrl := fmt.Sprintf("%s/archive/%s.tar.gz", p.Source.Remote, version)
 		archiveFilepath := fmt.Sprintf("%s.tar.gz", tmpDir)
 

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -36,7 +36,7 @@ func NewGitPackage(source *spec.GitSource) Interface {
 }
 
 func (p *GitPackage) Install(ctx context.Context, dir, version string) (lockVersion string, err error) {
-	cmd := exec.CommandContext(ctx, "git", "clone", p.Source.Remote, dir)
+	cmd := exec.CommandContext(ctx, "git", "clone", "-n", p.Source.Remote, dir)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -171,8 +171,17 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		if err != nil {
 			return "", err
 		}
+
 		r, err := os.Open(archiveFilepath)
+		if err != nil {
+			return "", err
+		}
+
 		err = gzipUntar(tmpDir, r, p.Source.Subdir)
+		if err != nil {
+			return "", err
+		}
+
 		return commitSha, nil
 	}
 

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -126,7 +126,7 @@ func gzipUntar(dst string, r io.Reader, subDir string) error {
 		// create directories as needed
 		case tar.TypeDir:
 			if _, err := os.Stat(target); err != nil {
-				if err := os.MkdirAll(target, 0755); err != nil {
+				if err := os.MkdirAll(target, os.FileMode(header.Mode)); err != nil {
 					return err
 				}
 			}

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -171,7 +171,7 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 	// the ETag header included in the response.
 	isGitHubRemote, err := regexp.MatchString(`^(https|ssh)://github\.com/.+$`, p.Source.Remote)
 	if isGitHubRemote {
-		archiveUrl := fmt.Sprintf("%s/archive/%s.tar.gzz", p.Source.Remote, version)
+		archiveUrl := fmt.Sprintf("%s/archive/%s.tar.gz", p.Source.Remote, version)
 		archiveFilepath := fmt.Sprintf("%s.tar.gz", tmpDir)
 
 		defer os.Remove(archiveFilepath)

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -141,6 +141,10 @@ func gzipUntar(dst string, r io.Reader, subDir string) error {
 			if _, err := io.Copy(f, tr); err != nil {
 				return err
 			}
+
+			// Explicitly release the file handle inside the inner loop
+			// Using defer would accumulate an unbounded quantity of
+			// handles and release them all at once at function end.
 			f.Close()
 		}
 	}


### PR DESCRIPTION
This introduces three distinct optimizations for install operations on Git packages (the only type supported in jb at this point):

* using GitHub tarball archive download whenever possible
* using shallow clone whenever possible
* use sparse checkouts whenever possible 

## GitHub archive download

The most efficient case. If the repo is from `https://github.com`, download a tarball at the requested revision. The ETag header contains the resolved commit SHA1. When unpacking the tarball, we can skip anything that isn't under the SubDir path since it won't be needed.

This does not require authentication with GitHub. At least, not for public repositories. Perhaps this needs some adjustment to avoid breaking private repo compatibility.

## Shallow clones

If the server supports it, perform a shallow clone (actually a `fetch`) of `--depth 1` so only the objects for the requested revision are downloaded. Not all servers support this, and some do it only if the request is reasonable (ie. it won't cause too much load on its side). For this reason, recover from the error and do a full fetch (all revisions). This has been tested to work with GitLab and GitHub (in some cases, but the archive download fast track covers those).

This change replaces the previous `git clone` step with distinct `git init`, `git remote add` and `git fetch` steps. This has the side effect of not creating an extra working copy before the `git checkout` step (ie. equivalent to `git clone -n`).

## Sparse checkouts

For cases where a sub directory is specified, there is no need to create a full working copy; the subdir path can act as a filter. Remember that there is no need to end up with a functional git repository since it will all be deleted by the time the package installer is done.

# Benchmarks

On _kube-prometheus_:

before:

```console
$ time jb install
real    0m32.044s
user    0m19.452s
sys     0m7.984s
```

after:

```console
$ time jb install
real    0m7.921s
user    0m1.575s
sys     0m0.622s
```

YMMV.

Will happily accept any criticism on my Go style as I am still learning this language and its standard library. For a future improvement, I would love to make the package installs concurrent (or at least, the IO-bound operations like downloads).