### PR TITLE
Replace ETag SHA1 assumption with an explicit call to git ls-remote

### DIFF
--- a/pkg/git.go
+++ b/pkg/git.go
@@ -178,7 +178,7 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 
 		// If the ref resolution failed and "version" looks like a SHA1, assume it is one
 		// and proceed.
-		commitShaPattern, _ := regexp.Compile("^([0-9a-f]{40})$")
+		commitShaPattern := regexp.MustCompile("^([0-9a-f]{40})$")
 		if commitSha == "" && commitShaPattern.MatchString(version) {
 			commitSha = version
 		}

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -53,7 +53,7 @@ func downloadGitHubArchive(filepath string, url string) error {
 	}
 	color.Cyan("GET %s %d", url, resp.StatusCode)
 	if resp.StatusCode != 200 {
-		return errors.New(fmt.Sprintf("unexpected status code %d", resp.StatusCode))
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 
 	defer resp.Body.Close()

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -144,7 +144,7 @@ func gzipUntar(dst string, r io.Reader, subDir string) error {
 }
 
 func remoteResolveRef(ctx context.Context, remote string, ref string) (string, error) {
-	b := bytes.NewBuffer(nil)
+	b := &bytes.Buffer{}
 	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--heads", "--tags", "--refs", "--quiet", remote, ref)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = b

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -153,7 +153,7 @@ func remoteResolveRef(ctx context.Context, remote string, ref string) (string, e
 	if err != nil {
 		return "", err
 	}
-	commitShaPattern, _ := regexp.Compile("^([0-9a-f]{40})\\b")
+	commitShaPattern := regexp.MustCompile("^([0-9a-f]{40,})\\b")
 	commitSha := commitShaPattern.FindString(b.String())
 	return commitSha, nil
 }
@@ -176,9 +176,9 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		// but possible event that a ref is exactly 40 hex characters
 		commitSha, err := remoteResolveRef(ctx, p.Source.Remote, version)
 
-		// If the ref resolution failed and "version" looks like a SHA1, assume it is one
-		// and proceed.
-		commitShaPattern := regexp.MustCompile("^([0-9a-f]{40})$")
+		// If the ref resolution failed and "version" looks like a SHA,
+		// assume it is one and proceed.
+		commitShaPattern := regexp.MustCompile("^([0-9a-f]{40,})$")
 		if commitSha == "" && commitShaPattern.MatchString(version) {
 			commitSha = version
 		}

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -168,12 +168,11 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 	defer os.RemoveAll(tmpDir)
 
 	// Optimization for GitHub sources: download a tarball archive of the requested
-	// version instead of cloning the entire repository. The SHA1 is discovered through
-	// the ETag header included in the response.
+	// version instead of cloning the entire repository.
 	isGitHubRemote, err := regexp.MatchString(`^(https|ssh)://github\.com/.+$`, p.Source.Remote)
 	if isGitHubRemote {
-		// Let git ls-remote decide if "version" is a ref or a SHA1 in the unlikely
-		// but possible event that a ref is exactly 40 hex characters
+		// Let git ls-remote decide if "version" is a ref or a commit SHA in the unlikely
+		// but possible event that a ref is comprised of 40 or more hex characters
 		commitSha, err := remoteResolveRef(ctx, p.Source.Remote, version)
 
 		// If the ref resolution failed and "version" looks like a SHA,


### PR DESCRIPTION
Not using an undocumented ETag header from the GitHub archive API is
probably for the best. This is slightly slower due to extra round-trip,
but it is still much faster than cloning the repository to resolve the
ref.

Fixes #46 