### PR TITLE
only write jsonnnet files if we made changes

### DIFF
--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -37,7 +37,7 @@ func installCommand(dir, jsonnetHome string, uris []string) int {
 	jbfilebytes, err := ioutil.ReadFile(filepath.Join(dir, jsonnetfile.File))
 	kingpin.FatalIfError(err, "failed to load jsonnetfile")
 
-	jsonnetFile, err := jsonnetfile.UnmarshalBytes(jbfilebytes)
+	jsonnetFile, err := jsonnetfile.Unmarshal(jbfilebytes)
 	kingpin.FatalIfError(err, "")
 
 	jblockfilebytes, err := ioutil.ReadFile(filepath.Join(dir, jsonnetfile.LockFile))
@@ -45,7 +45,7 @@ func installCommand(dir, jsonnetHome string, uris []string) int {
 		kingpin.FatalIfError(err, "failed to load lockfile")
 	}
 
-	lockFile, err := jsonnetfile.UnmarshalBytes(jblockfilebytes)
+	lockFile, err := jsonnetfile.Unmarshal(jblockfilebytes)
 	kingpin.FatalIfError(err, "")
 
 	kingpin.FatalIfError(
@@ -100,7 +100,7 @@ func writeJSONFile(name string, d interface{}) error {
 }
 
 func writeChangedJsonnetFile(originalBytes []byte, modified *spec.JsonnetFile, path string) error {
-	origJsonnetFile, err := jsonnetfile.UnmarshalBytes(originalBytes)
+	origJsonnetFile, err := jsonnetfile.Unmarshal(originalBytes)
 	if err != nil {
 		return err
 	}

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -35,10 +35,9 @@ func TestInstallCommand(t *testing.T) {
 		ExpectedJsonnetLockFile []byte
 	}{
 		{
-			Name:                    "NoURLs",
-			ExpectedCode:            0,
-			ExpectedJsonnetFile:     []byte(`{"dependencies":null}`),
-			ExpectedJsonnetLockFile: []byte(`{"dependencies":null}`),
+			Name:                "NoURLs",
+			ExpectedCode:        0,
+			ExpectedJsonnetFile: []byte(`{}`),
 		}, {
 			Name:                    "OneURL",
 			URIs:                    []string{"github.com/jsonnet-bundler/jsonnet-bundler@v0.1.0"},
@@ -77,7 +76,9 @@ func TestInstallCommand(t *testing.T) {
 			installCommand("", "vendor", tc.URIs)
 
 			jsonnetFileContent(t, jsonnetfile.File, tc.ExpectedJsonnetFile)
-			jsonnetFileContent(t, jsonnetfile.LockFile, tc.ExpectedJsonnetLockFile)
+			if tc.ExpectedJsonnetLockFile != nil {
+				jsonnetFileContent(t, jsonnetfile.LockFile, tc.ExpectedJsonnetLockFile)
+			}
 		})
 	}
 

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/jsonnet-bundler/jsonnet-bundler/pkg/jsonnetfile"
+	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
 )
 
 func TestInstallCommand(t *testing.T) {
@@ -92,5 +93,87 @@ func jsonnetFileContent(t *testing.T, filename string, content []byte) {
 	assert.NoError(t, err)
 	if eq := assert.JSONEq(t, string(content), string(bytes)); !eq {
 		t.Log(string(bytes))
+	}
+}
+
+func TestWriteChangedJsonnetFile(t *testing.T) {
+	testcases := []struct {
+		Name             string
+		JsonnetFileBytes []byte
+		NewJsonnetFile   spec.JsonnetFile
+		ExpectWrite      bool
+	}{
+		{
+			Name:             "NoDiffEmpty",
+			JsonnetFileBytes: []byte(`{}`),
+			NewJsonnetFile:   spec.New(),
+			ExpectWrite:      false,
+		},
+		{
+			Name:             "NoDiffNotEmpty",
+			JsonnetFileBytes: []byte(`{"dependencies": [{"name": "foobar"}]}`),
+			NewJsonnetFile: spec.JsonnetFile{
+				Dependencies: map[string]spec.Dependency{
+					"foobar": {
+						Name: "foobar",
+					},
+				},
+			},
+			ExpectWrite: false,
+		},
+		{
+			Name:             "DiffVersion",
+			JsonnetFileBytes: []byte(`{"dependencies": [{"name": "foobar", "version": "1.0"}]}`),
+			NewJsonnetFile: spec.JsonnetFile{
+				Dependencies: map[string]spec.Dependency{
+					"foobar": {
+						Name:    "foobar",
+						Version: "2.0",
+					},
+				},
+			},
+			ExpectWrite: true,
+		},
+		{
+			Name:             "Diff",
+			JsonnetFileBytes: []byte(`{}`),
+			NewJsonnetFile: spec.JsonnetFile{
+				Dependencies: map[string]spec.Dependency{
+					"foobar": {
+						Name: "foobar",
+						Source: spec.Source{
+							GitSource: &spec.GitSource{
+								Remote: "https://github.com/foobar/foobar",
+								Subdir: "",
+							},
+						},
+						Version:   "master",
+						DepSource: "",
+					}},
+			},
+			ExpectWrite: true,
+		},
+	}
+	outputjsonnetfile := "changedjsonnet.json"
+	for _, tc := range testcases {
+		_ = t.Run(tc.Name, func(t *testing.T) {
+			clean := func() {
+				_ = os.Remove(outputjsonnetfile)
+			}
+			clean()
+			defer clean()
+
+			err := writeChangedJsonnetFile(tc.JsonnetFileBytes, &tc.NewJsonnetFile, outputjsonnetfile)
+			assert.NoError(t, err)
+
+			if tc.ExpectWrite {
+				assert.FileExists(t, outputjsonnetfile)
+			} else {
+				_, err := os.Lstat(outputjsonnetfile)
+				if err != nil {
+					assert.True(t, os.IsNotExist(err))
+				}
+			}
+		})
 	}
 }

--- a/pkg/jsonnetfile/jsonnetfile.go
+++ b/pkg/jsonnetfile/jsonnetfile.go
@@ -38,12 +38,12 @@ func Load(filepath string) (spec.JsonnetFile, error) {
 		return spec.New(), err
 	}
 
-	return UnmarshalBytes(bytes)
+	return Unmarshal(bytes)
 }
 
-// UnmarshalBytes creates a spec.JsonnetFile from bytes. Empty bytes
+// Unmarshal creates a spec.JsonnetFile from bytes. Empty bytes
 // will create an empty spec.
-func UnmarshalBytes(bytes []byte) (spec.JsonnetFile, error) {
+func Unmarshal(bytes []byte) (spec.JsonnetFile, error) {
 	m := spec.New()
 	if len(bytes) == 0 {
 		return m, nil

--- a/pkg/jsonnetfile/jsonnetfile.go
+++ b/pkg/jsonnetfile/jsonnetfile.go
@@ -38,12 +38,12 @@ func Load(filepath string) (spec.JsonnetFile, error) {
 		return spec.New(), err
 	}
 
-	return UnmarshalJsonnetBytes(bytes)
+	return UnmarshalBytes(bytes)
 }
 
-// UnmarshalJsonnetBytes creates a spec.JsonnetFile from bytes. Empty bytes
+// UnmarshalBytes creates a spec.JsonnetFile from bytes. Empty bytes
 // will create an empty spec.
-func UnmarshalJsonnetBytes(bytes []byte) (spec.JsonnetFile, error) {
+func UnmarshalBytes(bytes []byte) (spec.JsonnetFile, error) {
 	m := spec.New()
 	if len(bytes) == 0 {
 		return m, nil

--- a/pkg/jsonnetfile/jsonnetfile.go
+++ b/pkg/jsonnetfile/jsonnetfile.go
@@ -33,13 +33,21 @@ var ErrNoFile = errors.New("no jsonnetfile")
 
 // Load reads a jsonnetfile.(lock).json from disk
 func Load(filepath string) (spec.JsonnetFile, error) {
-	m := spec.New()
-
 	bytes, err := ioutil.ReadFile(filepath)
 	if err != nil {
-		return m, err
+		return spec.New(), err
 	}
 
+	return UnmarshalJsonnetBytes(bytes)
+}
+
+// UnmarshalJsonnetBytes creates a spec.JsonnetFile from bytes. Empty bytes
+// will create an empty spec.
+func UnmarshalJsonnetBytes(bytes []byte) (spec.JsonnetFile, error) {
+	m := spec.New()
+	if len(bytes) == 0 {
+		return m, nil
+	}
 	if err := json.Unmarshal(bytes, &m); err != nil {
 		return m, errors.Wrap(err, "failed to unmarshal file")
 	}


### PR DESCRIPTION
Adding a dep, or updating a dependency version makes writes to the
jsonnet files.

We evaluate the changes on each of the files. An empty jsonnetfile.json
does not create a corresponding lockfile, as a missing lockfile is not
different from its previous (non existent) state.

closes #11