### PR TITLE
add --tags option to git-fetch to make sure tags will be fetched

### DIFF
--- a/pkg/git.go
+++ b/pkg/git.go
@@ -241,7 +241,7 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 	}
 
 	// Attempt shallow fetch at specific revision
-	cmd = exec.CommandContext(ctx, "git", "fetch", "--depth", "1", "origin", version)
+	cmd = exec.CommandContext(ctx, "git", "fetch", "--tags", "--depth", "1", "origin", version)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This is to fix the issue described in https://github.com/jsonnet-bundler/jsonnet-bundler/issues/57, with this patch I'm able to install a tag.