### PR TITLE
Test for 3 latest Go versions in CI

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,55 +1,54 @@
-{
-  _config+:: {
-    golang: 'golang:1.13',
-  },
-
-  kind: 'pipeline',
-  name: 'build',
-  platform: {
-    os: 'linux',
-    arch: 'amd64',
-  },
-
-  local golang = {
-    name: 'golang',
-    image: $._config.golang,
-    pull: 'always',
-    environment: {
-      CGO_ENABLED: '0',
-      GO111MODULE: 'on',
+[
+  {
+    kind: 'pipeline',
+    name: 'go%s' % version,
+    platform: {
+      os: 'linux',
+      arch: 'amd64',
     },
-    when: {
-      event: {
-        exclude: ['tag'],
+
+    local golang = {
+      name: 'golang',
+      image: 'golang:%s' % version,
+      pull: 'always',
+      environment: {
+        CGO_ENABLED: '0',
+        GO111MODULE: 'on',
+      },
+      when: {
+        event: {
+          exclude: ['tag'],
+        },
       },
     },
-  },
 
-  steps: [
-    golang {
-      name: 'gomod',
-      commands: [
-        'go mod vendor',
-        'git diff --exit-code',
-      ],
-    },
+    steps: [
+      golang {
+        name: 'gomod',
+        commands: [
+          'go mod vendor',
+          'git diff --exit-code',
+        ],
+      },
 
-    golang {
-      name: 'build',
-      commands: [
-        'make build',
-        'make test',
-        'make test-integration',
-      ],
-    },
+      golang {
+        name: 'build',
+        commands: [
+          'make build',
+          'make test',
+          'make test-integration',
+        ],
+      },
 
-    golang {
-      name: 'generate',
-      commands: [
-        'make check-license',
-        'make generate',
-        'git diff --exit-code',
-      ],
-    },
-  ],
-}
+      golang {
+        name: 'generate',
+        commands: [
+          'make check-license',
+          'make generate',
+          'git diff --exit-code',
+        ],
+      },
+    ],
+  }
+  for version in ['1.13', '1.12', '1.11']
+]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: build
+name: go1.13
 
 platform:
   os: linux
@@ -39,6 +39,112 @@ steps:
 - name: generate
   pull: always
   image: golang:1.13
+  commands:
+  - make check-license
+  - make generate
+  - git diff --exit-code
+  environment:
+    CGO_ENABLED: 0
+    GO111MODULE: on
+  when:
+    event:
+      exclude:
+      - tag
+
+---
+kind: pipeline
+name: go1.12
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: gomod
+  pull: always
+  image: golang:1.12
+  commands:
+  - go mod vendor
+  - git diff --exit-code
+  environment:
+    CGO_ENABLED: 0
+    GO111MODULE: on
+  when:
+    event:
+      exclude:
+      - tag
+
+- name: build
+  pull: always
+  image: golang:1.12
+  commands:
+  - make build
+  - make test
+  - make test-integration
+  environment:
+    CGO_ENABLED: 0
+    GO111MODULE: on
+  when:
+    event:
+      exclude:
+      - tag
+
+- name: generate
+  pull: always
+  image: golang:1.12
+  commands:
+  - make check-license
+  - make generate
+  - git diff --exit-code
+  environment:
+    CGO_ENABLED: 0
+    GO111MODULE: on
+  when:
+    event:
+      exclude:
+      - tag
+
+---
+kind: pipeline
+name: go1.11
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: gomod
+  pull: always
+  image: golang:1.11
+  commands:
+  - go mod vendor
+  - git diff --exit-code
+  environment:
+    CGO_ENABLED: 0
+    GO111MODULE: on
+  when:
+    event:
+      exclude:
+      - tag
+
+- name: build
+  pull: always
+  image: golang:1.11
+  commands:
+  - make build
+  - make test
+  - make test-integration
+  environment:
+    CGO_ENABLED: 0
+    GO111MODULE: on
+  when:
+    event:
+      exclude:
+      - tag
+
+- name: generate
+  pull: always
+  image: golang:1.11
   commands:
   - make check-license
   - make generate

--- a/pkg/local.go
+++ b/pkg/local.go
@@ -16,11 +16,11 @@ package pkg
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec"
+	"github.com/pkg/errors"
 )
 
 type LocalPackage struct {
@@ -36,7 +36,7 @@ func NewLocalPackage(source *spec.LocalSource) Interface {
 func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (lockVersion string, err error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("failed to get current working directory: %w", err)
+		return "", errors.Wrap(err, "failed to get current working directory: %w")
 	}
 
 	oldname := filepath.Join(wd, p.Source.Directory)
@@ -44,17 +44,17 @@ func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (
 
 	err = os.RemoveAll(newname)
 	if err != nil {
-		return "", fmt.Errorf("failed to clean previous destination path: %w", err)
+		return "", errors.Wrap(err, "failed to clean previous destination path: %w")
 	}
 
 	_, err = os.Stat(oldname)
 	if os.IsNotExist(err) {
-		return "", fmt.Errorf("symlink destination path does not exist: %w", err)
+		return "", errors.Wrap(err, "symlink destination path does not exist: %w")
 	}
 
 	err = os.Symlink(oldname, newname)
 	if err != nil {
-		return "", fmt.Errorf("failed to create symlink for local dependency: %w", err)
+		return "", errors.Wrap(err, "failed to create symlink for local dependency: %w")
 	}
 
 	return "", nil


### PR DESCRIPTION
We should probably support the 3 latest Go versions when our primary installation method is `go get`. I think 3 latest versions is what the Go teams supports? If not we should adjust.

This PR is currently failing because we already use the new Go error handling that was introduced in Go 1.13 and thus breaks users with prior versions.

/cc @sh0rez @brancz @bgagnon