### PR TITLE
fix: Git ssh-scp syntax

### DIFF
--- a/cmd/jb/main_test.go
+++ b/cmd/jb/main_test.go
@@ -64,7 +64,7 @@ func TestParseDependency(t *testing.T) {
 		},
 		{
 			name: "SSH",
-			path: "git+ssh://git@github.com:jsonnet-bundler/jsonnet-bundler.git",
+			path: "git+ssh://git@github.com/jsonnet-bundler/jsonnet-bundler.git",
 			want: &deps.Dependency{
 				Source: deps.Source{
 					GitSource: &deps.Git{

--- a/spec/deps/git.go
+++ b/spec/deps/git.go
@@ -87,7 +87,7 @@ func (gs *Git) LegacyName() string {
 }
 
 var gitProtoFmts = map[string]string{
-	GitSchemeSSH:   GitSchemeSSH + "%s:%s/%s.git",
+	GitSchemeSSH:   GitSchemeSSH + "%s/%s/%s.git",
 	GitSchemeHTTPS: GitSchemeHTTPS + "%s/%s/%s",
 }
 
@@ -100,7 +100,7 @@ func (gs *Git) Remote() string {
 
 // regular expressions for matching package uris
 const (
-	gitSSHExp     = `git\+ssh://git@(?P<host>[^:]+):(?P<user>[^/]+)/(?P<repo>[^/]+).git`
+	gitSSHExp     = `ssh://git@(?P<host>.+)/(?P<user>.+)/(?P<repo>.+).git`
 	githubSlugExp = `github.com/(?P<user>[-_a-zA-Z0-9]+)/(?P<repo>[-_a-zA-Z0-9]+)`
 )
 

--- a/spec/deps/git.go
+++ b/spec/deps/git.go
@@ -101,19 +101,17 @@ func (gs *Git) Remote() string {
 // regular expressions for matching package uris
 const (
 	gitSSHExp     = `ssh://git@(?P<host>.+)/(?P<user>.+)/(?P<repo>.+).git`
+	gitSCPExp     = `^git@(?P<host>.+):(?P<user>.+)/(?P<repo>.+).git`
 	githubSlugExp = `github.com/(?P<user>[-_a-zA-Z0-9]+)/(?P<repo>[-_a-zA-Z0-9]+)`
 )
 
 var (
-	gitSSHRegex                   = regexp.MustCompile(gitSSHExp)
-	gitSSHWithVersionRegex        = regexp.MustCompile(gitSSHExp + `@(?P<version>.*)`)
-	gitSSHWithPathRegex           = regexp.MustCompile(gitSSHExp + `/(?P<subdir>.*)`)
-	gitSSHWithPathAndVersionRegex = regexp.MustCompile(gitSSHExp + `/(?P<subdir>.*)@(?P<version>.*)`)
+	gitSSHRegex     = regexp.MustCompile(gitSSHExp)
+	githubSlugRegex = regexp.MustCompile(githubSlugExp)
 
-	githubSlugRegex                   = regexp.MustCompile(githubSlugExp)
-	githubSlugWithVersionRegex        = regexp.MustCompile(githubSlugExp + `@(?P<version>.*)`)
-	githubSlugWithPathRegex           = regexp.MustCompile(githubSlugExp + `/(?P<subdir>.*)`)
-	githubSlugWithPathAndVersionRegex = regexp.MustCompile(githubSlugExp + `/(?P<subdir>.*)@(?P<version>.*)`)
+	VersionRegex        = `@(?P<version>.*)`
+	PathRegex           = `/(?P<subdir>.*)`
+	PathAndVersionRegex = `/(?P<subdir>.*)@(?P<version>.*)`
 )
 
 func parseGit(uri string) *Dependency {
@@ -125,10 +123,16 @@ func parseGit(uri string) *Dependency {
 	var version string
 
 	switch {
-	case githubSlugRegex.MatchString(uri):
-		gs, version = parseGitHub(uri)
-	case gitSSHRegex.MatchString(uri):
-		gs, version = parseGitSSH(uri)
+	case reMatch(githubSlugExp, uri):
+		gs, version = match(uri, githubSlugExp)
+		gs.Scheme = GitSchemeHTTPS
+		gs.Host = "github.com"
+	case reMatch(gitSSHExp, uri):
+		gs, version = match(uri, gitSSHExp)
+		gs.Scheme = GitSchemeSSH
+	case reMatch(gitSCPExp, uri):
+		gs, version = match(uri, gitSCPExp)
+		gs.Scheme = GitSchemeSSH
 	default:
 		return nil
 	}
@@ -144,33 +148,16 @@ func parseGit(uri string) *Dependency {
 	return &d
 }
 
-func parseGitSSH(p string) (gs *Git, version string) {
-	gs, version = match(p, []*regexp.Regexp{
-		gitSSHWithPathAndVersionRegex,
-		gitSSHWithPathRegex,
-		gitSSHWithVersionRegex,
-		gitSSHRegex,
-	})
-
-	gs.Scheme = GitSchemeSSH
-	return gs, version
-}
-
-func parseGitHub(p string) (gs *Git, version string) {
-	gs, version = match(p, []*regexp.Regexp{
-		githubSlugWithPathAndVersionRegex,
-		githubSlugWithPathRegex,
-		githubSlugWithVersionRegex,
-		githubSlugRegex,
-	})
-
-	gs.Scheme = GitSchemeHTTPS
-	gs.Host = "github.com"
-	return gs, version
-}
-
-func match(p string, exps []*regexp.Regexp) (gs *Git, version string) {
+func match(p string, exp string) (gs *Git, version string) {
 	gs = &Git{}
+
+	exps := []*regexp.Regexp{
+		regexp.MustCompile(exp + PathAndVersionRegex),
+		regexp.MustCompile(exp + PathRegex),
+		regexp.MustCompile(exp + VersionRegex),
+		regexp.MustCompile(exp),
+	}
+
 	for _, e := range exps {
 		if !e.MatchString(p) {
 			continue
@@ -188,6 +175,10 @@ func match(p string, exps []*regexp.Regexp) (gs *Git, version string) {
 		return gs, matches["version"]
 	}
 	return gs, ""
+}
+
+func reMatch(exp string, str string) bool {
+	return regexp.MustCompile(exp).MatchString(str)
 }
 
 func reSubMatchMap(r *regexp.Regexp, str string) map[string]string {

--- a/spec/deps/git.go
+++ b/spec/deps/git.go
@@ -123,16 +123,16 @@ func parseGit(uri string) *Dependency {
 	var version string
 
 	switch {
-	case reMatch(githubSlugExp, uri):
-		gs, version = match(uri, githubSlugExp)
-		gs.Scheme = GitSchemeHTTPS
-		gs.Host = "github.com"
 	case reMatch(gitSSHExp, uri):
 		gs, version = match(uri, gitSSHExp)
 		gs.Scheme = GitSchemeSSH
 	case reMatch(gitSCPExp, uri):
 		gs, version = match(uri, gitSCPExp)
 		gs.Scheme = GitSchemeSSH
+	case reMatch(githubSlugExp, uri):
+		gs, version = match(uri, githubSlugExp)
+		gs.Scheme = GitSchemeHTTPS
+		gs.Host = "github.com"
 	default:
 		return nil
 	}

--- a/spec/deps/git_test.go
+++ b/spec/deps/git_test.go
@@ -25,7 +25,7 @@ func TestParseGit(t *testing.T) {
 		Version: "v1",
 		Source: Source{GitSource: &Git{
 			Scheme: GitSchemeSSH,
-			Host:   "my.host",
+			Host:   "github.com",
 			User:   "user",
 			Repo:   "repo",
 			Subdir: "/foobar",
@@ -55,15 +55,15 @@ func TestParseGit(t *testing.T) {
 		},
 		{
 			name:       "ssh.ssh",
-			uri:        "ssh://git@my.host/user/repo.git/foobar@v1",
+			uri:        "ssh://git@github.com/user/repo.git/foobar@v1",
 			want:       sshWant,
-			wantRemote: "ssh://git@my.host/user/repo.git",
+			wantRemote: "ssh://git@github.com/user/repo.git",
 		},
 		{
 			name:       "ssh.scp",
-			uri:        "git@my.host:user/repo.git/foobar@v1",
+			uri:        "git@github.com:user/repo.git/foobar@v1",
 			want:       sshWant,
-			wantRemote: "ssh://git@my.host/user/repo.git", // want ssh format here
+			wantRemote: "ssh://git@github.com/user/repo.git", // want ssh format here
 		},
 	}
 

--- a/spec/deps/git_test.go
+++ b/spec/deps/git_test.go
@@ -21,15 +21,17 @@ import (
 )
 
 func TestParseGit(t *testing.T) {
-	sshWant := &Dependency{
-		Version: "v1",
-		Source: Source{GitSource: &Git{
-			Scheme: GitSchemeSSH,
-			Host:   "github.com",
-			User:   "user",
-			Repo:   "repo",
-			Subdir: "/foobar",
-		}},
+	sshWant := func(host string) *Dependency {
+		return &Dependency{
+			Version: "v1",
+			Source: Source{GitSource: &Git{
+				Scheme: GitSchemeSSH,
+				Host:   host,
+				User:   "user",
+				Repo:   "repo",
+				Subdir: "/foobar",
+			}},
+		}
 	}
 
 	tests := []struct {
@@ -55,15 +57,15 @@ func TestParseGit(t *testing.T) {
 		},
 		{
 			name:       "ssh.ssh",
-			uri:        "ssh://git@github.com/user/repo.git/foobar@v1",
-			want:       sshWant,
-			wantRemote: "ssh://git@github.com/user/repo.git",
+			uri:        "ssh://git@example.com/user/repo.git/foobar@v1",
+			want:       sshWant("example.com"),
+			wantRemote: "ssh://git@example.com/user/repo.git",
 		},
 		{
 			name:       "ssh.scp",
-			uri:        "git@github.com:user/repo.git/foobar@v1",
-			want:       sshWant,
-			wantRemote: "ssh://git@github.com/user/repo.git", // want ssh format here
+			uri:        "git@my.host:user/repo.git/foobar@v1",
+			want:       sshWant("my.host"),
+			wantRemote: "ssh://git@my.host/user/repo.git", // want ssh format here
 		},
 	}
 


### PR DESCRIPTION
- fixes the ssh:// syntax
- adds proper support for scp style (`git@github.com:user/repo.git`, note no `ssh://` and the colon)

The tests were extended to properly cover this.

The scp syntax is internally rewritten to the SSH one, so there won't be any confusion around this

Fixes #67 