### PR TITLE
Allow generic git repos over HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 _output/
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _output/
+.vscode

--- a/cmd/jb/main_test.go
+++ b/cmd/jb/main_test.go
@@ -43,17 +43,17 @@ func TestParseDependency(t *testing.T) {
 		},
 		{
 			name: "Invalid",
-			path: "github.com/foo",
+			path: "example.com/foo",
 			want: nil,
 		},
 		{
-			name: "GitHub",
-			path: "github.com/jsonnet-bundler/jsonnet-bundler",
+			name: "GitHTTPS",
+			path: "example.com/jsonnet-bundler/jsonnet-bundler",
 			want: &deps.Dependency{
 				Source: deps.Source{
 					GitSource: &deps.Git{
 						Scheme: deps.GitSchemeHTTPS,
-						Host:   "github.com",
+						Host:   "example.com",
 						User:   "jsonnet-bundler",
 						Repo:   "jsonnet-bundler",
 						Subdir: "",
@@ -64,12 +64,12 @@ func TestParseDependency(t *testing.T) {
 		},
 		{
 			name: "SSH",
-			path: "git+ssh://git@github.com:jsonnet-bundler/jsonnet-bundler.git",
+			path: "git+ssh://git@example.com:jsonnet-bundler/jsonnet-bundler.git",
 			want: &deps.Dependency{
 				Source: deps.Source{
 					GitSource: &deps.Git{
 						Scheme: deps.GitSchemeSSH,
-						Host:   "github.com",
+						Host:   "example.com",
 						User:   "jsonnet-bundler",
 						Repo:   "jsonnet-bundler",
 						Subdir: "",

--- a/cmd/jb/main_test.go
+++ b/cmd/jb/main_test.go
@@ -64,7 +64,7 @@ func TestParseDependency(t *testing.T) {
 		},
 		{
 			name: "SSH",
-			path: "git+ssh://git@github.com/jsonnet-bundler/jsonnet-bundler.git",
+			path: "git+ssh://git@example.com/jsonnet-bundler/jsonnet-bundler.git",
 			want: &deps.Dependency{
 				Source: deps.Source{
 					GitSource: &deps.Git{

--- a/cmd/jb/main_test.go
+++ b/cmd/jb/main_test.go
@@ -64,12 +64,12 @@ func TestParseDependency(t *testing.T) {
 		},
 		{
 			name: "SSH",
-			path: "git+ssh://git@example.com/jsonnet-bundler/jsonnet-bundler.git",
+			path: "git+ssh://git@github.com/jsonnet-bundler/jsonnet-bundler.git",
 			want: &deps.Dependency{
 				Source: deps.Source{
 					GitSource: &deps.Git{
 						Scheme: deps.GitSchemeSSH,
-						Host:   "example.com",
+						Host:   "github.com",
 						User:   "jsonnet-bundler",
 						Repo:   "jsonnet-bundler",
 						Subdir: "",

--- a/spec/deps/dependencies_test.go
+++ b/spec/deps/dependencies_test.go
@@ -40,7 +40,17 @@ func TestParseDependency(t *testing.T) {
 		},
 		{
 			name: "Invalid",
-			path: "github.com/foo",
+			path: "example.com/foo",
+			want: nil,
+		},
+		{
+			name: "InvalidDomain",
+			path: "example.c/foo/bar",
+			want: nil,
+		},
+		{
+			name: "InvalidDomain2",
+			path: "examplec/foo/bar",
 			want: nil,
 		},
 		{

--- a/spec/deps/git.go
+++ b/spec/deps/git.go
@@ -100,8 +100,9 @@ func (gs *Git) Remote() string {
 
 // regular expressions for matching package uris
 const (
-	gitSSHExp  = `ssh://git@(?P<host>.+)/(?P<user>.+)/(?P<repo>.+).git`
-	gitSCPExp  = `^git@(?P<host>.+):(?P<user>.+)/(?P<repo>.+).git`
+	gitSSHExp = `ssh://git@(?P<host>.+)/(?P<user>.+)/(?P<repo>.+).git`
+	gitSCPExp = `^git@(?P<host>.+):(?P<user>.+)/(?P<repo>.+).git`
+	// The long ugly pattern for ${host} here is a generic pattern for "valid URL with zero or more subdomains and a valid TLD"
 	gitSlugExp = `(?P<scheme>https://)?(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9]+)/(?P<repo>[-_a-zA-Z0-9]+)`
 )
 

--- a/spec/deps/git.go
+++ b/spec/deps/git.go
@@ -81,7 +81,7 @@ func (gs *Git) Name() string {
 }
 
 // LegacyName returns the last element of the packages path
-// example: example.com/ksonnet/ksonnet-lib/ksonnet.beta.4 becomes ksonnet.beta.4
+// example: github.com/ksonnet/ksonnet-lib/ksonnet.beta.4 becomes ksonnet.beta.4
 func (gs *Git) LegacyName() string {
 	return filepath.Base(gs.Repo + gs.Subdir)
 }
@@ -103,13 +103,10 @@ const (
 	gitSSHExp = `ssh://git@(?P<host>.+)/(?P<user>.+)/(?P<repo>.+).git`
 	gitSCPExp = `^git@(?P<host>.+):(?P<user>.+)/(?P<repo>.+).git`
 	// The long ugly pattern for ${host} here is a generic pattern for "valid URL with zero or more subdomains and a valid TLD"
-	gitSlugExp = `(?P<scheme>https://)?(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9]+)/(?P<repo>[-_a-zA-Z0-9]+)`
+	gitHTTPSExp = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9]+)/(?P<repo>[-_a-zA-Z0-9]+)`
 )
 
 var (
-	gitSSHRegex  = regexp.MustCompile(gitSSHExp)
-	gitSlugRegex = regexp.MustCompile(gitSlugExp)
-
 	VersionRegex        = `@(?P<version>.*)`
 	PathRegex           = `/(?P<subdir>.*)`
 	PathAndVersionRegex = `/(?P<subdir>.*)@(?P<version>.*)`
@@ -130,8 +127,8 @@ func parseGit(uri string) *Dependency {
 	case reMatch(gitSCPExp, uri):
 		gs, version = match(uri, gitSCPExp)
 		gs.Scheme = GitSchemeSSH
-	case reMatch(gitSlugExp, uri):
-		gs, version = match(uri, gitSlugExp)
+	case reMatch(gitHTTPSExp, uri):
+		gs, version = match(uri, gitHTTPSExp)
 		gs.Scheme = GitSchemeHTTPS
 	default:
 		return nil
@@ -166,7 +163,6 @@ func match(p string, exp string) (gs *Git, version string) {
 		gs.Host = matches["host"]
 		gs.User = matches["user"]
 		gs.Repo = matches["repo"]
-		gs.Scheme = matches["scheme"]
 
 		if sd, ok := matches["subdir"]; ok {
 			gs.Subdir = sd

--- a/spec/deps/git_test.go
+++ b/spec/deps/git_test.go
@@ -56,6 +56,108 @@ func TestParseGit(t *testing.T) {
 			},
 			wantRemote: "ssh://git@my.host:user/repo.git",
 		},
+		{
+			name: "ValidGitHTTPS",
+			uri:  "https://example.com/foo/bar",
+			want: &Dependency{
+				Version: "master",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "example.com",
+						User:   "foo",
+						Repo:   "bar",
+						Subdir: "",
+					},
+				},
+			},
+			wantRemote: "https://example.com/foo/bar",
+		},
+		{
+			name: "ValidGitNoScheme",
+			uri:  "example.com/foo/bar",
+			want: &Dependency{
+				Version: "master",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "example.com",
+						User:   "foo",
+						Repo:   "bar",
+						Subdir: "",
+					},
+				},
+			},
+			wantRemote: "https://example.com/foo/bar",
+		},
+		{
+			name: "ValidGitPath",
+			uri:  "example.com/foo/bar/baz/bat",
+			want: &Dependency{
+				Version: "master",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "example.com",
+						User:   "foo",
+						Repo:   "bar",
+						Subdir: "/baz/bat",
+					},
+				},
+			},
+			wantRemote: "https://example.com/foo/bar",
+		},
+		{
+			name: "ValidGitVersion",
+			uri:  "example.com/foo/bar@baz",
+			want: &Dependency{
+				Version: "baz",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "example.com",
+						User:   "foo",
+						Repo:   "bar",
+						Subdir: "",
+					},
+				},
+			},
+			wantRemote: "https://example.com/foo/bar",
+		},
+		{
+			name: "ValidGitPathVersion",
+			uri:  "example.com/foo/bar/baz@bat",
+			want: &Dependency{
+				Version: "bat",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "example.com",
+						User:   "foo",
+						Repo:   "bar",
+						Subdir: "/baz",
+					},
+				},
+			},
+			wantRemote: "https://example.com/foo/bar",
+		},
+		{
+			name: "ValidGitSubdomain",
+			uri:  "git.example.com/foo/bar",
+			want: &Dependency{
+				Version: "master",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "git.example.com",
+						User:   "foo",
+						Repo:   "bar",
+						Subdir: "",
+					},
+				},
+			},
+			wantRemote: "https://git.example.com/foo/bar",
+		},
 	}
 
 	for _, c := range tests {


### PR DESCRIPTION
This PR should resolve #72 and allow generic git-over-https dependencies. I've added some tests to ensure that various success paths are still working, as well as a couple of additional failure cases.

The Github-specific behaviors are still present in the form of the archive download optimizations, but there is no longer any up-front assumption that Github will be the only non-SSH dep source.

Would love your feedback! Thanks.