### PR TITLE
Add an 'override' command

### DIFF
--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -30,7 +30,7 @@ import (
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec/deps"
 )
 
-func installCommand(dir, jsonnetHome string, uris []string) int {
+func installCommand(dir, jsonnetHome string, uris []string, transitive bool) int {
 	if dir == "" {
 		dir = "."
 	}
@@ -68,7 +68,7 @@ func installCommand(dir, jsonnetHome string, uris []string) int {
 		}
 	}
 
-	locked, err := pkg.Ensure(jsonnetFile, jsonnetHome, lockFile.Dependencies)
+	locked, err := pkg.Ensure(jsonnetFile, jsonnetHome, lockFile.Dependencies, transitive)
 	kingpin.FatalIfError(err, "failed to install packages")
 
 	pkg.CleanLegacyName(jsonnetFile.Dependencies)

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -81,7 +81,7 @@ func TestInstallCommand(t *testing.T) {
 			jsonnetFileContent(t, jsonnetfile.File, []byte(initContents))
 
 			// install something, check it writes only if required, etc.
-			installCommand("", "vendor", tc.URIs)
+			installCommand("", "vendor", tc.URIs, true)
 			jsonnetFileContent(t, jsonnetfile.File, tc.ExpectedJsonnetFile)
 			if tc.ExpectedJsonnetLockFile != nil {
 				jsonnetFileContent(t, jsonnetfile.LockFile, tc.ExpectedJsonnetLockFile)

--- a/cmd/jb/update.go
+++ b/cmd/jb/update.go
@@ -41,7 +41,7 @@ func updateCommand(dir, jsonnetHome string, urls ...*url.URL) int {
 
 	// When updating, locks are ignored.
 	locks := map[string]deps.Dependency{}
-	locked, err := pkg.Ensure(jsonnetFile, jsonnetHome, locks)
+	locked, err := pkg.Ensure(jsonnetFile, jsonnetHome, locks, true)
 	kingpin.FatalIfError(err, "failed to install packages")
 
 	kingpin.FatalIfError(

--- a/pkg/jsonnetfile/jsonnetfile.go
+++ b/pkg/jsonnetfile/jsonnetfile.go
@@ -25,7 +25,7 @@ import (
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec/deps"
 )
 
-const (
+var (
 	File     = "jsonnetfile.json"
 	LockFile = "jsonnetfile.lock.json"
 )


### PR DESCRIPTION
The purpose of this command is to allow downloading a direct dependency without any of its transitive dependencies.  The use case for this currently is very Tanka specific, allowing someone to navigate to a specific environment and run `jb override ...` and download just the direct dependency into a vendor folder inside a single environment.

Recent versions of Tanka will check for a vendor folder inside the environment before checking the projects vendor folder.  This allows you to install a different version of a vendored dependency in an environment and gives a graceful way of testing new vendored dependencies in a single environment before updating the projects vendor dep and globally applying the change.

Some thoughts about this PR:

The `override` command is currently a wrapper for the install command, we could instead add a flag to the install command that is something like `-transitive=false` however I would rather not do this as it complicates the use of this feature (but also recognizing this feature's use and even name `override` makes the most sense in context of using Tanka)

Changing the global variable names for the jsonnet file is necessary for Tanka, and also i think useful in making someone aware this is different from the normal jsonnet files.  However changing global variables never feels great to me, it's a much larger change but we could add struct to the jsonnetfile.go which includes the file and lockfile names as members and then start passing this around.  

For convenience I wrapped the init command when doing override to create the jsonnet files if they don't exist, wondering if this might be nice to also do for the normal install command?