### PR TITLE
fix: allow other dirs than vendor

### DIFF
--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -32,6 +32,18 @@ import (
 const initContents = `{"dependencies": [], "legacyImports": true}`
 
 func TestInstallCommand(t *testing.T) {
+	testInstallCommandWithJsonnetHome(t, "vendor")
+}
+
+func TestInstallCommandCustomJsonnetHome(t *testing.T) {
+	testInstallCommandWithJsonnetHome(t, "custom-vendor-dir")
+}
+
+func TestInstallCommandDeepCustomJsonnetHome(t *testing.T) {
+	testInstallCommandWithJsonnetHome(t, "custom/vendor/dir")
+}
+
+func testInstallCommandWithJsonnetHome(t *testing.T, jsonnetHome string) {
 	testcases := []struct {
 		Name                    string
 		URIs                    []string
@@ -65,7 +77,7 @@ func TestInstallCommand(t *testing.T) {
 	cleanup := func() {
 		_ = os.Remove(jsonnetfile.File)
 		_ = os.Remove(jsonnetfile.LockFile)
-		_ = os.RemoveAll("vendor")
+		_ = os.RemoveAll(jsonnetHome)
 		_ = os.RemoveAll("jsonnet")
 	}
 
@@ -81,7 +93,7 @@ func TestInstallCommand(t *testing.T) {
 			jsonnetFileContent(t, jsonnetfile.File, []byte(initContents))
 
 			// install something, check it writes only if required, etc.
-			installCommand("", "vendor", tc.URIs)
+			installCommand("", jsonnetHome, tc.URIs)
 			jsonnetFileContent(t, jsonnetfile.File, tc.ExpectedJsonnetFile)
 			if tc.ExpectedJsonnetLockFile != nil {
 				jsonnetFileContent(t, jsonnetfile.LockFile, tc.ExpectedJsonnetLockFile)

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -66,6 +67,8 @@ func Main() int {
 	if err != nil {
 		return 1
 	}
+
+	cfg.JsonnetHome = filepath.Clean(cfg.JsonnetHome)
 
 	switch command {
 	case initCmd.FullCommand():

--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -76,7 +76,10 @@ func Ensure(direct spec.JsonnetFile, vendorDir string, oldLocks map[string]deps.
 
 	// remove them
 	for _, dir := range names {
-		name := strings.TrimPrefix(dir, "vendor/")
+		name, err := filepath.Rel(vendorDir, dir)
+		if err != nil {
+			return nil, err
+		}
 		if !known(locks, name) {
 			if err := os.RemoveAll(dir); err != nil {
 				return nil, err
@@ -147,7 +150,7 @@ func linkLegacy(vendorDir string, locks map[string]deps.Dependency) error {
 			continue
 		}
 
-		legacyName := filepath.Join("vendor", d.LegacyName())
+		legacyName := filepath.Join(vendorDir, d.LegacyName())
 		pkgName := d.Name()
 
 		taken, err := checkLegacyNameTaken(legacyName, pkgName)

--- a/tool/rewrite/rewrite_test.go
+++ b/tool/rewrite/rewrite_test.go
@@ -48,6 +48,18 @@ const want = `
 `
 
 func TestRewrite(t *testing.T) {
+	testRewriteWithJsonnetHome(t, "vendor")
+}
+
+func TestRewriteCustomJsonnetHome(t *testing.T) {
+	testRewriteWithJsonnetHome(t, "custom-vendor-dir")
+}
+
+func TestRewriteDeepCustomJsonnetHome(t *testing.T) {
+	testRewriteWithJsonnetHome(t, "custom/vendor/dir")
+}
+
+func testRewriteWithJsonnetHome(t *testing.T, jsonnetHome string) {
 	dir, err := ioutil.TempDir("", "jbrewrite")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
@@ -56,11 +68,11 @@ func TestRewrite(t *testing.T) {
 	err = ioutil.WriteFile(name, []byte(sample), 0644)
 	require.Nil(t, err)
 
-	vendorDir := filepath.Join(dir, "vendor")
+	vendorDir := filepath.Join(dir, jsonnetHome)
 	err = os.MkdirAll(vendorDir, os.ModePerm)
 	require.Nil(t, err)
 
-	err = Rewrite(dir, "vendor", locks)
+	err = Rewrite(dir, jsonnetHome, locks)
 	require.Nil(t, err)
 
 	content, err := ioutil.ReadFile(name)


### PR DESCRIPTION
This is to address https://github.com/jsonnet-bundler/jsonnet-bundler/issues/71, changes in this PR:
1. Replace hardcoded "vendor" with proper value from command line
2. Change test to target non-default vendor directory (replace `vendor` with `test-vendor-dir`)
3. Make sure vendor dir from command line does not containe trailing `/`