### PR TITLE
Fix unarchiver

### DIFF
--- a/pkg/git.go
+++ b/pkg/git.go
@@ -233,40 +233,33 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		color.Yellow("retrying with git...")
 	}
 
-	cmd := exec.CommandContext(ctx, "git", "init")
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Dir = tmpDir
+	gitCmd := func(args ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Dir = tmpDir
+		return cmd
+	}
+
+	cmd := gitCmd("init")
 	err = cmd.Run()
 	if err != nil {
 		return "", err
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "remote", "add", "origin", p.Source.Remote())
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Dir = tmpDir
+	cmd = gitCmd("remote", "add", "origin", p.Source.Remote())
 	err = cmd.Run()
 	if err != nil {
 		return "", err
 	}
 
 	// Attempt shallow fetch at specific revision
-	cmd = exec.CommandContext(ctx, "git", "fetch", "--tags", "--depth", "1", "origin", version)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Dir = tmpDir
+	cmd = gitCmd("fetch", "--tags", "--depth", "1", "origin", version)
 	err = cmd.Run()
 	if err != nil {
 		// Fall back to normal fetch (all revisions)
-		cmd = exec.CommandContext(ctx, "git", "fetch", "origin")
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Dir = tmpDir
+		cmd = gitCmd("fetch", "origin")
 		err = cmd.Run()
 		if err != nil {
 			return "", err
@@ -276,11 +269,7 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 	// Sparse checkout optimization: if a Subdir is specified,
 	// there is no need to do a full checkout
 	if p.Source.Subdir != "" {
-		cmd = exec.CommandContext(ctx, "git", "config", "core.sparsecheckout", "true")
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Dir = tmpDir
+		cmd = gitCmd("config", "core.sparsecheckout", "true")
 		err = cmd.Run()
 		if err != nil {
 			return "", err
@@ -293,11 +282,7 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		}
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "-c", "advice.detachedHead=false", "checkout", version)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Dir = tmpDir
+	cmd = gitCmd("-c", "advice.detachedHead=false", "checkout", version)
 	err = cmd.Run()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
While investigating #62, I came across an [error shadowing](https://github.com/jsonnet-bundler/jsonnet-bundler/compare/master...davidovich:fix-unarchiver?expand=1#diff-f3708aa6fdbaa2ed2eb6897499e0941fL199-L200) bug that silences archive errors. Later code relies on the same `err` variable to determine if it should try the git clone if the archive cannot be restored.

Plus, file unarchiving should always verify directory creation because the tar archive member iteration may yield file before enclosing folders.

This PR fixes the shadowing, ensures directory creation and improves somewhat on code repetitions.