### PR TITLE
fix: proper parsing of v0

### DIFF
--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
 )
 
-const initContents = `{"version": 1, "dependencies": [], "legacyImports": false}`
+const initContents = `{"version": 1, "dependencies": [], "legacyImports": true}`
 
 func TestInstallCommand(t *testing.T) {
 	testInstallCommandWithJsonnetHome(t, "vendor")
@@ -59,14 +59,14 @@ func testInstallCommandWithJsonnetHome(t *testing.T, jsonnetHome string) {
 			Name:                    "OneURL",
 			URIs:                    []string{"github.com/jsonnet-bundler/jsonnet-bundler@v0.1.0"},
 			ExpectedCode:            0,
-			ExpectedJsonnetFile:     []byte(`{"version": 1, "dependencies": [{"source": {"git": {"remote": "https://github.com/jsonnet-bundler/jsonnet-bundler", "subdir": ""}}, "version": "v0.1.0"}], "legacyImports": false}`),
+			ExpectedJsonnetFile:     []byte(`{"version": 1, "dependencies": [{"source": {"git": {"remote": "https://github.com/jsonnet-bundler/jsonnet-bundler", "subdir": ""}}, "version": "v0.1.0"}], "legacyImports": true}`),
 			ExpectedJsonnetLockFile: []byte(`{"version": 1, "dependencies": [{"source": {"git": {"remote": "https://github.com/jsonnet-bundler/jsonnet-bundler", "subdir": ""}}, "version": "080f157c7fb85ad0281ea78f6c641eaa570a582f", "sum": "W1uI550rQ66axRpPXA2EZDquyPg/5PHZlvUz1NEzefg="}], "legacyImports": false}`),
 		},
 		{
 			Name:                    "Local",
 			URIs:                    []string{"jsonnet/foobar"},
 			ExpectedCode:            0,
-			ExpectedJsonnetFile:     []byte(`{"version": 1, "dependencies": [{"source": {"local": {"directory": "jsonnet/foobar"}}, "version": ""}], "legacyImports": false}`),
+			ExpectedJsonnetFile:     []byte(`{"version": 1, "dependencies": [{"source": {"local": {"directory": "jsonnet/foobar"}}, "version": ""}], "legacyImports": true}`),
 			ExpectedJsonnetLockFile: []byte(`{"version": 1, "dependencies": [{"source": {"local": {"directory": "jsonnet/foobar"}}, "version": ""}], "legacyImports": false}`),
 		},
 	}

--- a/pkg/jsonnetfile/jsonnetfile_test.go
+++ b/pkg/jsonnetfile/jsonnetfile_test.go
@@ -210,7 +210,7 @@ func TestLoadEmpty(t *testing.T) {
 
 	// write empty json file
 	tempFile := filepath.Join(tempDir, jsonnetfile.File)
-	err = ioutil.WriteFile(tempFile, []byte(`{"version":1}`), os.ModePerm)
+	err = ioutil.WriteFile(tempFile, []byte(`{}`), os.ModePerm)
 	assert.Nil(t, err)
 
 	// expect it to be loaded properly

--- a/pkg/jsonnetfile/jsonnetfile_test.go
+++ b/pkg/jsonnetfile/jsonnetfile_test.go
@@ -31,58 +31,60 @@ const notExist = "/this/does/not/exist"
 
 const v0JSON = `{
   "dependencies": [
-    {
-      "name": "grafana-builder",
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
-          "subdir": "grafana-builder"
-        }
-      },
-      "version": "54865853ebc1f901964e25a2e7a0e4d2cb6b9648",
-      "sum": "ELsYwK+kGdzX1mee2Yy+/b2mdO4Y503BOCDkFzwmGbE="
-    },
-    {
-      "name": "prometheus-mixin",
-      "source": {
-        "git": {
-          "remote": "https://github.com/prometheus/prometheus",
-          "subdir": "documentation/prometheus-mixin"
-        }
-      },
-      "version": "7c039a6b3b4b2a9d7c613ac8bd3fc16e8ca79684",
-      "sum": "bVGOsq3hLOw2irNPAS91a5dZJqQlBUNWy3pVwM4+kIY="
-    }
+	{
+	  "name": "grafana-builder",
+	  "source": {
+		"git": {
+		  "remote": "https://github.com/grafana/jsonnet-libs",
+		  "subdir": "grafana-builder"
+		}
+	  },
+	  "version": "54865853ebc1f901964e25a2e7a0e4d2cb6b9648",
+	  "sum": "ELsYwK+kGdzX1mee2Yy+/b2mdO4Y503BOCDkFzwmGbE="
+	},
+	{
+	  "name": "prometheus-mixin",
+	  "source": {
+		"git": {
+		  "remote": "https://github.com/prometheus/prometheus",
+		  "subdir": "documentation/prometheus-mixin"
+		}
+	  },
+	  "version": "7c039a6b3b4b2a9d7c613ac8bd3fc16e8ca79684",
+	  "sum": "bVGOsq3hLOw2irNPAS91a5dZJqQlBUNWy3pVwM4+kIY="
+	}
   ]
 }`
 
 var v0Jsonnetfile = v1.JsonnetFile{
 	Dependencies: map[string]deps.Dependency{
-		"grafana-builder": {
+		"github.com/grafana/jsonnet-libs/grafana-builder": {
 			Source: deps.Source{
 				GitSource: &deps.Git{
 					Scheme: deps.GitSchemeHTTPS,
 					Host:   "github.com",
 					User:   "grafana",
 					Repo:   "jsonnet-libs",
-					Subdir: "grafana-builder",
+					Subdir: "/grafana-builder",
 				},
 			},
-			Version: "54865853ebc1f901964e25a2e7a0e4d2cb6b9648",
-			Sum:     "ELsYwK+kGdzX1mee2Yy+/b2mdO4Y503BOCDkFzwmGbE=",
+			Version:          "54865853ebc1f901964e25a2e7a0e4d2cb6b9648",
+			Sum:              "ELsYwK+kGdzX1mee2Yy+/b2mdO4Y503BOCDkFzwmGbE=",
+			LegacyNameCompat: "grafana-builder",
 		},
-		"prometheus-mixin": {
+		"github.com/prometheus/prometheus/documentation/prometheus-mixin": {
 			Source: deps.Source{
 				GitSource: &deps.Git{
 					Scheme: deps.GitSchemeHTTPS,
 					Host:   "github.com",
 					User:   "prometheus",
 					Repo:   "prometheus",
-					Subdir: "documentation/prometheus-mixin",
+					Subdir: "/documentation/prometheus-mixin",
 				},
 			},
-			Version: "7c039a6b3b4b2a9d7c613ac8bd3fc16e8ca79684",
-			Sum:     "bVGOsq3hLOw2irNPAS91a5dZJqQlBUNWy3pVwM4+kIY=",
+			Version:          "7c039a6b3b4b2a9d7c613ac8bd3fc16e8ca79684",
+			Sum:              "bVGOsq3hLOw2irNPAS91a5dZJqQlBUNWy3pVwM4+kIY=",
+			LegacyNameCompat: "prometheus-mixin",
 		},
 	},
 	LegacyImports: true,
@@ -91,27 +93,27 @@ var v0Jsonnetfile = v1.JsonnetFile{
 const v1JSON = `{
   "version": 1,
   "dependencies": [
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs",
-          "subdir": "grafana-builder"
-        }
-      },
-      "version": "54865853ebc1f901964e25a2e7a0e4d2cb6b9648",
-      "sum": "ELsYwK+kGdzX1mee2Yy+/b2mdO4Y503BOCDkFzwmGbE="
-    },
-    {
-      "name": "prometheus",
-      "source": {
-        "git": {
-          "remote": "https://github.com/prometheus/prometheus",
-          "subdir": "documentation/prometheus-mixin"
-        }
-      },
-      "version": "7c039a6b3b4b2a9d7c613ac8bd3fc16e8ca79684",
-      "sum": "bVGOsq3hLOw2irNPAS91a5dZJqQlBUNWy3pVwM4+kIY="
-    }
+	{
+	  "source": {
+		"git": {
+		  "remote": "https://github.com/grafana/jsonnet-libs",
+		  "subdir": "grafana-builder"
+		}
+	  },
+	  "version": "54865853ebc1f901964e25a2e7a0e4d2cb6b9648",
+	  "sum": "ELsYwK+kGdzX1mee2Yy+/b2mdO4Y503BOCDkFzwmGbE="
+	},
+	{
+	  "name": "prometheus",
+	  "source": {
+		"git": {
+		  "remote": "https://github.com/prometheus/prometheus",
+		  "subdir": "documentation/prometheus-mixin"
+		}
+	  },
+	  "version": "7c039a6b3b4b2a9d7c613ac8bd3fc16e8ca79684",
+	  "sum": "bVGOsq3hLOw2irNPAS91a5dZJqQlBUNWy3pVwM4+kIY="
+	}
   ],
   "legacyImports": false
 }`

--- a/spec/v0/spec.go
+++ b/spec/v0/spec.go
@@ -19,6 +19,8 @@ import (
 	"sort"
 )
 
+const Version = 0
+
 // JsonnetFile is the structure of a `.json` file describing a set of jsonnet
 // dependencies. It is used for both, the jsonnetFile and the lockFile.
 type JsonnetFile struct {

--- a/spec/v1/spec.go
+++ b/spec/v1/spec.go
@@ -73,6 +73,7 @@ func (jf JsonnetFile) MarshalJSON() ([]byte, error) {
 	var s jsonFile
 
 	s.Version = Version
+	s.LegacyImports = jf.LegacyImports
 
 	for _, d := range jf.Dependencies {
 		s.Dependencies = append(s.Dependencies, d)

--- a/spec/v1/v0.go
+++ b/spec/v1/v0.go
@@ -18,8 +18,10 @@ func FromV0(mv0 v0.JsonnetFile) (JsonnetFile, error) {
 		case old.Source.GitSource != nil:
 			d = *deps.Parse("", old.Source.GitSource.Remote)
 
-			subdir := filepath.Clean("/" + old.Source.GitSource.Subdir)
-			d.Source.GitSource.Subdir = subdir
+			if old.Source.GitSource.Subdir != "" {
+				subdir := filepath.Clean("/" + old.Source.GitSource.Subdir)
+				d.Source.GitSource.Subdir = subdir
+			}
 
 		case old.Source.LocalSource != nil:
 			d = *deps.Parse("", old.Source.LocalSource.Directory)

--- a/spec/v1/v0.go
+++ b/spec/v1/v0.go
@@ -1,0 +1,36 @@
+package spec
+
+import (
+	"path/filepath"
+
+	v0 "github.com/jsonnet-bundler/jsonnet-bundler/spec/v0"
+	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
+)
+
+func FromV0(mv0 v0.JsonnetFile) (JsonnetFile, error) {
+	m := New()
+	m.LegacyImports = true
+
+	for name, old := range mv0.Dependencies {
+		var d deps.Dependency
+
+		switch {
+		case old.Source.GitSource != nil:
+			d = *deps.Parse("", old.Source.GitSource.Remote)
+
+			subdir := filepath.Clean("/" + old.Source.GitSource.Subdir)
+			d.Source.GitSource.Subdir = subdir
+
+		case old.Source.LocalSource != nil:
+			d = *deps.Parse("", old.Source.LocalSource.Directory)
+		}
+
+		d.Sum = old.Sum
+		d.Version = old.Version
+		d.LegacyNameCompat = name
+
+		m.Dependencies[d.Name()] = d
+	}
+
+	return m, nil
+}

--- a/spec/v1/v0.go
+++ b/spec/v1/v0.go
@@ -1,3 +1,16 @@
+// Copyright 2018 jsonnet-bundler authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package spec
 
 import (


### PR DESCRIPTION
With the most latest change (#85), jb basically broke, because it was not able to properly parse files anymore, as there were mistakes made in translating v0 to v1.

**Unfortunately we realized this _after_ releasing, so this patch is kinda urgent to provide users with a usable version**