### PR TITLE
Add support for subgroups

### DIFF
--- a/spec/v1/deps/git.go
+++ b/spec/v1/deps/git.go
@@ -106,7 +106,8 @@ const (
 	gitSSHExp = `ssh://git@(?P<host>.+)/(?P<user>.+)/(?P<repo>.+).git`
 	gitSCPExp = `^git@(?P<host>.+):(?P<user>.+)/(?P<repo>.+).git`
 	// The long ugly pattern for ${host} here is a generic pattern for "valid URL with zero or more subdomains and a valid TLD"
-	gitHTTPSExp = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9]+)/(?P<repo>[-_a-zA-Z0-9]+)`
+	gitHTTPSSubgroup = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9/]+)/(?P<repo>[-_a-zA-Z0-9]+)\.git`
+	gitHTTPSExp      = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9]+)/(?P<repo>[-_a-zA-Z0-9]+)`
 )
 
 var (
@@ -130,6 +131,9 @@ func parseGit(uri string) *Dependency {
 	case reMatch(gitSCPExp, uri):
 		gs, version = match(uri, gitSCPExp)
 		gs.Scheme = GitSchemeSSH
+	case reMatch(gitHTTPSSubgroup, uri):
+		gs, version = match(uri, gitHTTPSSubgroup)
+		gs.Scheme = GitSchemeHTTPS
 	case reMatch(gitHTTPSExp, uri):
 		gs, version = match(uri, gitHTTPSExp)
 		gs.Scheme = GitSchemeHTTPS

--- a/spec/v1/deps/git_test.go
+++ b/spec/v1/deps/git_test.go
@@ -169,6 +169,40 @@ func TestParseGit(t *testing.T) {
 			},
 			wantRemote: "https://git.example.com/foo/bar",
 		},
+		{
+			name: "ValidGitSubgroups",
+			uri:  "example.com/group/subgroup/repository.git",
+			want: &Dependency{
+				Version: "master",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "example.com",
+						User:   "group/subgroup",
+						Repo:   "repository",
+						Subdir: "",
+					},
+				},
+			},
+			wantRemote: "https://example.com/group/subgroup/repository",
+		},
+		{
+			name: "ValidGitSubgroupSubDir",
+			uri:  "example.com/group/subgroup/repository.git/subdir",
+			want: &Dependency{
+				Version: "master",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "example.com",
+						User:   "group/subgroup",
+						Repo:   "repository",
+						Subdir: "/subdir",
+					},
+				},
+			},
+			wantRemote: "https://example.com/group/subgroup/repository",
+		},
 	}
 
 	for _, c := range tests {


### PR DESCRIPTION
When using Subgroups (for example as provided by GitLab) `jb` cannot distinguish the nested repository and a subpath inside of the repository. This issue is also unique to HTTP since the ssh protocol already expects a full-length directory.

This PR fixes this issue by allowing the user to explicitly specify the repository part by suffixing it with `.git`.