### PR TITLE
feat(install): skip dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Commands:
   init
     Initialize a new empty jsonnetfile
 
-  install [<uris>...]
+  install [<flags>] [<uris>...]
     Install new dependencies. Existing ones are silently skipped
 
   update [<uris>...]

--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -30,7 +30,7 @@ import (
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
 )
 
-func installCommand(dir, jsonnetHome string, uris []string) int {
+func installCommand(dir, jsonnetHome string, uris []string, single bool) int {
 	if dir == "" {
 		dir = "."
 	}
@@ -57,6 +57,10 @@ func installCommand(dir, jsonnetHome string, uris []string) int {
 		d := deps.Parse(dir, u)
 		if d == nil {
 			kingpin.Fatalf("Unable to parse package URI `%s`", u)
+		}
+
+		if single {
+			d.Single = true
 		}
 
 		if !depEqual(jsonnetFile.Dependencies[d.Name()], *d) {

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -72,9 +72,9 @@ func testInstallCommandWithJsonnetHome(t *testing.T, jsonnetHome string) {
 		},
 		{
 			Name:                    "single",
-			URIs:                    []string{"github.com/grafana/loki/production/ksonnet/loki"},
+			URIs:                    []string{"github.com/grafana/loki/production/ksonnet/loki@bd4d516262c107a0bde7a962fa2b1e567a2c21e5"},
 			ExpectedCode:            0,
-			ExpectedJsonnetFile:     []byte(`{"version":1,"dependencies":[{"source":{"git":{"remote":"https://github.com/grafana/loki","subdir":"production/ksonnet/loki"}},"version":"master","single":true}],"legacyImports":true}`),
+			ExpectedJsonnetFile:     []byte(`{"version":1,"dependencies":[{"source":{"git":{"remote":"https://github.com/grafana/loki","subdir":"production/ksonnet/loki"}},"version":"bd4d516262c107a0bde7a962fa2b1e567a2c21e5","single":true}],"legacyImports":true}`),
 			ExpectedJsonnetLockFile: []byte(`{"version":1,"dependencies":[{"source":{"git":{"remote":"https://github.com/grafana/loki","subdir":"production/ksonnet/loki"}},"version":"bd4d516262c107a0bde7a962fa2b1e567a2c21e5","sum":"ExovUKXmZ4KwJAv/q8ZwNW9BdIZlrxmoGrne7aR64wo=","single":true}],"legacyImports":false}`),
 			single:                  true,
 		},

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -49,6 +49,7 @@ func testInstallCommandWithJsonnetHome(t *testing.T, jsonnetHome string) {
 		ExpectedCode            int
 		ExpectedJsonnetFile     []byte
 		ExpectedJsonnetLockFile []byte
+		single                  bool
 	}{
 		{
 			Name:                "NoURLs",
@@ -68,6 +69,14 @@ func testInstallCommandWithJsonnetHome(t *testing.T, jsonnetHome string) {
 			ExpectedCode:            0,
 			ExpectedJsonnetFile:     []byte(`{"version": 1, "dependencies": [{"source": {"local": {"directory": "jsonnet/foobar"}}, "version": ""}], "legacyImports": true}`),
 			ExpectedJsonnetLockFile: []byte(`{"version": 1, "dependencies": [{"source": {"local": {"directory": "jsonnet/foobar"}}, "version": ""}], "legacyImports": false}`),
+		},
+		{
+			Name:                    "single",
+			URIs:                    []string{"github.com/grafana/loki/production/ksonnet/loki"},
+			ExpectedCode:            0,
+			ExpectedJsonnetFile:     []byte(`{"version":1,"dependencies":[{"source":{"git":{"remote":"https://github.com/grafana/loki","subdir":"production/ksonnet/loki"}},"version":"master","single":true}],"legacyImports":true}`),
+			ExpectedJsonnetLockFile: []byte(`{"version":1,"dependencies":[{"source":{"git":{"remote":"https://github.com/grafana/loki","subdir":"production/ksonnet/loki"}},"version":"bd4d516262c107a0bde7a962fa2b1e567a2c21e5","sum":"ExovUKXmZ4KwJAv/q8ZwNW9BdIZlrxmoGrne7aR64wo=","single":true}],"legacyImports":false}`),
+			single:                  true,
 		},
 	}
 
@@ -92,7 +101,7 @@ func testInstallCommandWithJsonnetHome(t *testing.T, jsonnetHome string) {
 			jsonnetFileContent(t, jsonnetfile.File, []byte(initContents))
 
 			// install something, check it writes only if required, etc.
-			installCommand("", jsonnetHome, tc.URIs)
+			installCommand("", jsonnetHome, tc.URIs, tc.single)
 			jsonnetFileContent(t, jsonnetfile.File, tc.ExpectedJsonnetFile)
 			if tc.ExpectedJsonnetLockFile != nil {
 				jsonnetFileContent(t, jsonnetfile.LockFile, tc.ExpectedJsonnetLockFile)

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -54,6 +54,7 @@ func Main() int {
 
 	installCmd := a.Command(installActionName, "Install new dependencies. Existing ones are silently skipped")
 	installCmdURIs := installCmd.Arg("uris", "URIs to packages to install, URLs or file paths").Strings()
+	installCmdSingle := installCmd.Flag("single", "install package without dependencies").Short('1').Bool()
 
 	updateCmd := a.Command(updateActionName, "Update all or specific dependencies.")
 	updateCmdURIs := updateCmd.Arg("uris", "URIs to packages to update, URLs or file paths").Strings()
@@ -78,13 +79,13 @@ func Main() int {
 	case initCmd.FullCommand():
 		return initCommand(workdir)
 	case installCmd.FullCommand():
-		return installCommand(workdir, cfg.JsonnetHome, *installCmdURIs)
+		return installCommand(workdir, cfg.JsonnetHome, *installCmdURIs, *installCmdSingle)
 	case updateCmd.FullCommand():
 		return updateCommand(workdir, cfg.JsonnetHome, *updateCmdURIs)
 	case rewriteCmd.FullCommand():
 		return rewriteCommand(workdir, cfg.JsonnetHome)
 	default:
-		installCommand(workdir, cfg.JsonnetHome, []string{})
+		installCommand(workdir, cfg.JsonnetHome, []string{}, false)
 	}
 
 	return 0

--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -243,6 +243,11 @@ func ensure(direct map[string]deps.Dependency, vendorDir string, locks map[strin
 	}
 
 	for _, d := range deps {
+		if d.Single {
+			// skip dependencies that explicitely don't want nested ones installed
+			continue
+		}
+
 		f, err := jsonnetfile.Load(filepath.Join(vendorDir, d.Name(), jsonnetfile.File))
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/spec/v1/deps/dependencies.go
+++ b/spec/v1/deps/dependencies.go
@@ -22,6 +22,7 @@ type Dependency struct {
 	Source  Source `json:"source"`
 	Version string `json:"version"`
 	Sum     string `json:"sum,omitempty"`
+	Single  bool   `json:"single,omitempty"`
 
 	// older schema used to have `name`. We still need that data for
 	// `LegacyName`


### PR DESCRIPTION
Allows `installing` a package without pulling dependencies of that
package. This comes in handy when having multiple directories on
`JPATH`, which overlay each other. (https://tanka.dev/libraries/import-paths)

Because dependencies may be already present at lesser ranked import
paths, it's not required to pull them, when only needing to bump a
single one.

/cc @slim-bean