### PR TITLE
Fix LocalPackage install for relative paths

### DIFF
--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -72,7 +72,8 @@ func installCommand(dir, jsonnetHome string, uris []string, single bool) int {
 		}
 	}
 
-	locked, err := pkg.Ensure(jsonnetFile, filepath.Join(dir, jsonnetHome), lockFile.Dependencies)
+	vendorDir := filepath.Join(dir, jsonnetHome)
+	locked, err := pkg.Ensure(jsonnetFile, vendorDir, lockFile.Dependencies)
 	kingpin.FatalIfError(err, "failed to install packages")
 
 	pkg.CleanLegacyName(jsonnetFile.Dependencies)

--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -72,8 +72,8 @@ func installCommand(dir, jsonnetHome string, uris []string, single bool) int {
 		}
 	}
 
-	vendorDir := filepath.Join(dir, jsonnetHome)
-	locked, err := pkg.Ensure(jsonnetFile, vendorDir, lockFile.Dependencies)
+	jsonnetPkgHomeDir := filepath.Join(dir, jsonnetHome)
+	locked, err := pkg.Ensure(jsonnetFile, jsonnetPkgHomeDir, lockFile.Dependencies)
 	kingpin.FatalIfError(err, "failed to install packages")
 
 	pkg.CleanLegacyName(jsonnetFile.Dependencies)

--- a/pkg/local.go
+++ b/pkg/local.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
@@ -41,7 +42,7 @@ func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (
 	}
 
 	oldname := filepath.Join(wd, p.Source.Directory)
-	newname := filepath.Join(wd, filepath.Join(dir, name))
+	newname := filepath.Join(dir, name)
 
 	err = os.RemoveAll(newname)
 	if err != nil {
@@ -57,6 +58,8 @@ func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create symlink for local dependency: %w")
 	}
+
+	color.Magenta("LOCAL %s -> %s", name, oldname)
 
 	return "", nil
 }

--- a/pkg/local_test.go
+++ b/pkg/local_test.go
@@ -1,0 +1,73 @@
+package pkg
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
+)
+
+func TestLocalInstall(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	vendorDir, err := ioutil.TempDir(cwd, "vendor")
+	assert.NoError(t, err)
+	defer os.RemoveAll(vendorDir)
+
+	pkgDir, err := ioutil.TempDir(cwd, "foo")
+	assert.NoError(t, err)
+	defer os.RemoveAll(pkgDir)
+
+	relPath, err := filepath.Rel(cwd, pkgDir)
+	assert.NoError(t, err)
+
+	p := NewLocalPackage(&deps.Local{Directory: relPath})
+	lockVersion, err := p.Install(context.TODO(), "foo", vendorDir, "v1.0")
+	assert.NoError(t, err)
+	assert.Empty(t, lockVersion)
+}
+
+func TestLocalInstallSourceNotFound(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	vendorDir, err := ioutil.TempDir(cwd, "vendor")
+	assert.NoError(t, err)
+	defer os.RemoveAll(vendorDir)
+
+	relPath := "foo"
+	p := NewLocalPackage(&deps.Local{Directory: relPath})
+	lockVersion, err := p.Install(context.TODO(), "foo", vendorDir, "v1.0")
+	assert.Error(t, err)
+	assert.Empty(t, lockVersion)
+}
+
+func TestLocalInstallTargetDoesNotExist(t *testing.T) {
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+
+	pkgDir, err := ioutil.TempDir(cwd, "foo")
+	assert.NoError(t, err)
+	defer os.RemoveAll(pkgDir)
+
+	relPath, err := filepath.Rel(cwd, pkgDir)
+	assert.NoError(t, err)
+
+	p := NewLocalPackage(&deps.Local{Directory: relPath})
+	lockVersion, err := p.Install(context.TODO(), "foo", "vendor", "v1.0")
+	assert.Error(t, err)
+	assert.Empty(t, lockVersion)
+}
+
+func TestLocalInstallSourceAndTargetDoNotExist(t *testing.T) {
+	p := NewLocalPackage(&deps.Local{Directory: "foo"})
+	lockVersion, err := p.Install(context.TODO(), "foo", "bar", "v1.0")
+	assert.Error(t, err)
+	assert.Empty(t, lockVersion)
+}


### PR DESCRIPTION
The vendor dir (here called `dir`) is already joined with the CWD in `installCommand()` a few frames higher. it should not be joined again here.

Also adds a logging message to show that a local package was installed. The operands and arrow match the look and feel of `ls -l` for symlinks.

~Sadly, there was no test coverage for `pgk/local.go`, so it's hard to tell if this patch breaks anything. I'd like to try and add some tests, but not sure what the best strategy is with the `os` calls.~