### PR TITLE
Use base of absolute path for local dependencies

### DIFF
--- a/spec/v1/deps/dependencies.go
+++ b/spec/v1/deps/dependencies.go
@@ -73,7 +73,11 @@ func (s Source) LegacyName() string {
 	case s.GitSource != nil:
 		return s.GitSource.LegacyName()
 	case s.LocalSource != nil:
-		return filepath.Base(s.LocalSource.Directory)
+		p, err := filepath.Abs(s.LocalSource.Directory)
+		if err != nil {
+			panic("unable to create absolute path from local source directory: " + err.Error())
+		}
+		return filepath.Base(p)
 	default:
 		return ""
 	}


### PR DESCRIPTION
This allows using local paths like "..", which previously messed up
environments.

@metalmatze @sh0rez @rollandf 