### PR TITLE
Create link for local dependencies as relative links

### DIFF
--- a/pkg/local.go
+++ b/pkg/local.go
@@ -43,6 +43,11 @@ func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (
 
 	oldname := filepath.Join(wd, p.Source.Directory)
 	newname := filepath.Join(dir, name)
+	linkname, err := filepath.Rel(dir, oldname)
+
+	if err != nil {
+		linkname = oldname
+	}
 
 	err = os.RemoveAll(newname)
 	if err != nil {
@@ -54,7 +59,7 @@ func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (
 		return "", errors.Wrap(err, "symlink destination path does not exist: %w")
 	}
 
-	err = os.Symlink(oldname, newname)
+	err = os.Symlink(linkname, newname)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create symlink for local dependency: %w")
 	}


### PR DESCRIPTION
The links for local packages are created with an absolute path.
This is can be an issue in case a user wants to add the vendor directory to a Git repo.

In this path, the link are created as relative to the `vendor` directory. If the path cannot be resolved as relative, the previous logic is used.