### PR TITLE
Fix: allow dots in a repository path's "user" section

### DIFF
--- a/spec/v1/deps/git.go
+++ b/spec/v1/deps/git.go
@@ -106,8 +106,8 @@ const (
 	gitSSHExp = `ssh://git@(?P<host>.+)/(?P<user>.+)/(?P<repo>.+).git`
 	gitSCPExp = `^git@(?P<host>.+):(?P<user>.+)/(?P<repo>.+).git`
 	// The long ugly pattern for ${host} here is a generic pattern for "valid URL with zero or more subdomains and a valid TLD"
-	gitHTTPSSubgroup = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9/]+)/(?P<repo>[-_a-zA-Z0-9]+)\.git`
-	gitHTTPSExp      = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9]+)/(?P<repo>[-_a-zA-Z0-9]+)`
+	gitHTTPSSubgroup = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9/\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)\.git`
+	gitHTTPSExp      = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)`
 )
 
 var (

--- a/spec/v1/deps/git_test.go
+++ b/spec/v1/deps/git_test.go
@@ -85,6 +85,23 @@ func TestParseGit(t *testing.T) {
 			wantRemote: "https://example.com/foo/bar.git",
 		},
 		{
+			name: "ValidGitLabUserGroupHTTPS",
+			uri:  "https://gitlab.example.com/first.last/project",
+			want: &Dependency{
+				Version: "master",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "gitlab.example.com",
+						User:   "first.last",
+						Repo:   "project",
+						Subdir: "",
+					},
+				},
+			},
+			wantRemote: "https://gitlab.example.com/first.last/project.git",
+		},
+		{
 			name: "ValidGitNoScheme",
 			uri:  "example.com/foo/bar",
 			want: &Dependency{


### PR DESCRIPTION
GitLab uses "first.last" naming for personal Groups. This fixes the ability to reference personal GitLab projects with jb.

Fixes #105 