### PR TITLE
Windows support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ cross: clean
 	CGO_ENABLED=0 gox \
 	  -output="$(OUT_DIR)/jb-{{.OS}}-{{.Arch}}" \
 	  -ldflags=$(LDFLAGS) \
-	  -arch="amd64 arm64 arm" -os="linux windows" \
+	  -arch="amd64 arm64 arm" -os="linux" \
 	  -osarch="darwin/amd64" \
+	  -osarch="windows/amd64" \
 	  ./cmd/$(BIN)
 
 static:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ cross: clean
 	CGO_ENABLED=0 gox \
 	  -output="$(OUT_DIR)/jb-{{.OS}}-{{.Arch}}" \
 	  -ldflags=$(LDFLAGS) \
-	  -arch="amd64 arm64 arm" -os="linux" \
+	  -arch="amd64 arm64 arm" -os="linux windows" \
 	  -osarch="darwin/amd64" \
 	  ./cmd/$(BIN)
 

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -179,7 +179,8 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 	destPath := path.Join(dir, name)
 
 	pkgh := sha256.Sum256([]byte(fmt.Sprintf("jsonnetpkg-%s-%s", strings.Replace(name, "/", "-", -1), version)))
-	tmpDir, err := ioutil.TempDir(filepath.Join(dir, ".tmp"), hex.EncodeToString(pkgh[:]))
+	// using 16 bytes should be a good middle ground between length and collision resistance
+	tmpDir, err := ioutil.TempDir(filepath.Join(dir, ".tmp"), hex.EncodeToString(pkgh[:16]))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create tmp dir")
 	}

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -19,6 +19,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -176,7 +178,8 @@ func remoteResolveRef(ctx context.Context, remote string, ref string) (string, e
 func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (string, error) {
 	destPath := path.Join(dir, name)
 
-	tmpDir, err := ioutil.TempDir(filepath.Join(dir, ".tmp"), fmt.Sprintf("jsonnetpkg-%s-%s", strings.Replace(name, "/", "-", -1), version))
+	pkgh := sha256.Sum256([]byte(fmt.Sprintf("jsonnetpkg-%s-%s", strings.Replace(name, "/", "-", -1), version)))
+	tmpDir, err := ioutil.TempDir(filepath.Join(dir, ".tmp"), hex.EncodeToString(pkgh[:]))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create tmp dir")
 	}

--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -200,6 +200,7 @@ func checkLegacyNameTaken(legacyName string, pkgName string) (bool, error) {
 }
 
 func known(deps map[string]deps.Dependency, p string) bool {
+	p = filepath.ToSlash(p)
 	for _, d := range deps {
 		k := d.Name()
 		if strings.HasPrefix(p, k) || strings.HasPrefix(k, p) {


### PR DESCRIPTION
This PR fixes some issues encountered when using `jb` under windows:

* Files got deleted directly after install since the pathspec in the jsonnetfile contained `/` while the path on disk contains backticks `\` as path seperator
* The length of the temp directories could easily exceed the length limits of windows file names

This PR fixes both of these issues.

To smoothly run `jb` in a heterogeneous environment, as of you also need to perform the following actions:

* enforce `lf` line endings on windows by adding a `.gitattributes` file to the library repository
    ```
    * text eol=lf
    ```
    this is required to get the correct checksum
* Either disable legacy imports or run as administrator since creation of symlinks is blocked by UAC by default.