### PR TITLE
Add --quiet option to suppress git progress output

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Flags:
       --version  Show application version.
       --jsonnetpkg-home="vendor"  
                  The directory used to cache packages in.
+  -q, --quiet    Suppress any output from git command.
 
 Commands:
   help [<command>...]

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -22,6 +22,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/jsonnet-bundler/jsonnet-bundler/pkg"
 )
 
 const (
@@ -49,6 +51,8 @@ func Main() int {
 
 	a.Flag("jsonnetpkg-home", "The directory used to cache packages in.").
 		Default("vendor").StringVar(&cfg.JsonnetHome)
+	a.Flag("quiet", "Suppress any output from git command.").
+		Short('q').BoolVar(&pkg.GitQuiet)
 
 	initCmd := a.Command(initActionName, "Initialize a new empty jsonnetfile")
 

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -48,13 +48,17 @@ func NewGitPackage(source *deps.Git) Interface {
 	}
 }
 
+var GitQuiet = false
+
 func downloadGitHubArchive(filepath string, url string) error {
 	// Get the data
 	resp, err := http.Get(url)
 	if err != nil {
 		return err
 	}
-	color.Cyan("GET %s %d", url, resp.StatusCode)
+	if !GitQuiet {
+		color.Cyan("GET %s %d", url, resp.StatusCode)
+	}
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
@@ -240,8 +244,13 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 	gitCmd := func(args ...string) *exec.Cmd {
 		cmd := exec.CommandContext(ctx, "git", args...)
 		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		if GitQuiet {
+			cmd.Stdout = nil
+			cmd.Stderr = nil
+		} else {
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+		}
 		cmd.Dir = tmpDir
 		return cmd
 	}


### PR DESCRIPTION
This is for https://github.com/jsonnet-bundler/jsonnet-bundler/issues/123, adding `--quiet/-q` to suppress stderr and stdout from git command.
