### PR TITLE
feat: Adding GoReleaser to handle releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -45,6 +45,7 @@
       auto_tag: true,
       password: { from_secret: 'docker_password' },
       repo: 'jsonnet/bundler',
+      target: 'production',
       username: { from_secret: 'docker_username' },
     },
     when: { event: 'tag' },

--- a/.drone.yml
+++ b/.drone.yml
@@ -118,6 +118,7 @@ steps:
     password:
       from_secret: docker_password
     repo: jsonnet/bundler
+    target: production
     username:
       from_secret: docker_username
   when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,9 +66,9 @@ steps:
       exclude:
       - tag
 
-- name: build-1.14-rc
+- name: build-1.14
   pull: always
-  image: golang:1.14-rc
+  image: golang:1.14
   commands:
   - make build
   - make test
@@ -95,5 +95,33 @@ steps:
     event:
       exclude:
       - tag
+
+- name: goreleaser
+  pull: always
+  image: golang:1.14
+  commands:
+  - curl -sL https://git.io/goreleaser | bash
+  environment:
+    CGO_ENABLED: 0
+    GITHUB_TOKEN:
+      from_secret: github_token
+    GO111MODULE: on
+  when:
+    event:
+    - tag
+
+- name: docker
+  pull: always
+  image: plugins/docker
+  settings:
+    auto_tag: true
+    password:
+      from_secret: docker_password
+    repo: jsonnet/bundler
+    username:
+      from_secret: docker_username
+  when:
+    event:
+    - tag
 
 ...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,17 +28,6 @@ builds:
       - -s -w -extldflags "-static" -X main.Version={{.Version}}
     main: ./cmd/jb
 dist: _output
-dockers:
-  - builds:
-      - jb
-    goarch: amd64
-    goos: linux
-    image_templates:
-      - jsonnet/bundler:latest
-      - jsonnet/bundler:v{{ .Major }}
-      - jsonnet/bundler:v{{ .Major }}.{{ .Minor }}
-      - jsonnet/bundler:{{ .Tag }}
-    skip_push: false
 project_name: jb
 release:
   draft: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,47 @@
+archives:
+  - builds:
+      - jb
+    format: binary
+    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}-{{ .Mips }}{{ end }}'
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+builds:
+  - binary: jb
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
+    goos:
+      - darwin
+      - linux
+      - windows
+    id: jb
+    ldflags:
+      - -s -w -extldflags "-static" -X main.Version={{.Version}}
+    main: ./cmd/jb
+dist: _output
+dockers:
+  - builds:
+      - jb
+    goarch: amd64
+    goos: linux
+    image_templates:
+      - jsonnet/bundler:latest
+      - jsonnet/bundler:v{{ .Major }}
+      - jsonnet/bundler:v{{ .Major }}.{{ .Minor }}
+      - jsonnet/bundler:{{ .Tag }}
+    skip_push: false
+project_name: jb
+release:
+  draft: true
+  github:
+    name: jsonnet-bundler
+    owner: jsonnet-bundler

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ builds:
     ldflags:
       - -s -w -extldflags "-static" -X main.Version={{.Version}}
     main: ./cmd/jb
+changelog:
+  skip: true
 dist: _output
 project_name: jb
 release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,30 @@
-FROM alpine:3.12
+###########
+# Builder #
+###########
 
-COPY jb /
+FROM golang:1.14-alpine AS builder
 
-ENTRYPOINT ["/jb"]
+# Switch to Go modules directory
+WORKDIR /go/src/github.com/jsonnet-bundler/jsonnet-bundler
+
+# Install build tools
+RUN apk add --no-cache alpine-sdk bash
+
+# Copy source directory
+COPY . .
+
+# Build static binary against Git version
+RUN make static
+
+########
+# Prod #
+########
+
+# Production image
+FROM alpine:3.12 AS production
+
+# Copy static binary from 'builder'
+COPY --from=builder /go/src/github.com/jsonnet-bundler/jsonnet-bundler/_output/jb /usr/local/bin/
+
+# Set image entrypoint
+ENTRYPOINT ["/usr/local/bin/jb"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM busybox:1.28
+FROM alpine:3.12
 
-COPY _output/linux/amd64/jb /
+COPY jb /
 
 ENTRYPOINT ["/jb"]

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,7 @@ all: check-license build generate test
 # Binaries
 LDFLAGS := '-s -w -extldflags "-static" -X main.Version=${VERSION}'
 cross: clean
-	CGO_ENABLED=0 gox \
-	  -output="$(OUT_DIR)/jb-{{.OS}}-{{.Arch}}" \
-	  -ldflags=$(LDFLAGS) \
-	  -arch="amd64 arm64 arm" -os="linux" \
-	  -osarch="darwin/amd64" \
-	  -osarch="windows/amd64" \
-	  ./cmd/$(BIN)
+	goreleaser --rm-dist --skip-publish --snapshot
 
 static:
 	CGO_ENABLED=0 go build -ldflags=${LDFLAGS} -o $(OUT_DIR)/$(BIN) ./cmd/$(BIN)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,32 @@ The jsonnet-bundler is a package manager for [Jsonnet](http://jsonnet.org/).
 
 ## Install
 
+### Go package
+
 ```
 GO111MODULE="on" go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 ```
 **NOTE**: please use a recent Go version to do this, ideally Go 1.13 or greater.
 
-This will put `jb` in `$(go env GOPATH)/bin`. If you encounter the error
-`jb: command not found` after installation then you may need to add that directory to your `$PATH` as shown [in their docs](https://golang.org/doc/code.html#GOPATH).
+This will put `jb` in `$(go env GOPATH)/bin`. If you encounter the error `jb: command not found` after installation then you may need to add that directory to your `$PATH` as shown [in their docs](https://golang.org/doc/code.html#GOPATH).
+
+### Docker
+
+The `jb` binary is available as a Docker image:
+
+```shell
+$ docker pull jsonnet/bundler
+
+$ alias jb='docker run --rm --interactive --tty --volume $(pwd):/repo --workdir /repo jsonnet/bundler:latest'
+```
+
+### Homebrew
+
+The `jb` binary is available via the `homebrew-core` repositories:
+
+```shell
+$ brew install jsonnet-bundler
+```
 
 ## Features
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/campoy/embedmd v1.0.0 // indirect
 	github.com/fatih/color v1.7.0
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
-github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=


### PR DESCRIPTION
Enables this repository to use [GoReleaser](https://github.com/goreleaser/goreleaser) to handle all releases. This PR is **_basically_** ready, it just needs some feedback from the maintainers.

## Description

By merging this PR, this repository will use [GoReleaser](https://github.com/goreleaser/goreleaser) for releasing of all artifacts. This includes, but is not limited to:

- Docker images
- GitHub releases with Go binaries pre-packaged
- Homebrew formulas

There are a number of issues to be addressed / questions to be answered by the maintainers of this project in order to merge this PR. See **Generic questions**.

The following is an example of the `_output` directory after running `make cross`, which triggers `goreleaser` ultimately:

```shell
$ tree _output

_output
├── config.yaml
├── goreleaserdocker799593599
│   ├── Dockerfile
│   └── jb
├── jb-darwin-amd64.tar.gz
├── jb-linux-amd64.tar.gz
├── jb-linux-arm64.tar.gz
├── jb-linux-armv6.tar.gz
├── jb-linux-armv7.tar.gz
├── jb-windows-amd64.zip
├── jb.rb
├── jb_darwin_amd64
│   └── jb
├── jb_linux_amd64
│   └── jb
├── jb_linux_arm64
│   └── jb
├── jb_linux_arm_6
│   └── jb
├── jb_linux_arm_7
│   └── jb
├── jb_v0.4.0-SNAPSHOT-7a629bf_checksums.txt
└── jb_windows_amd64
    └── jb.exe

7 directories, 17 files
```

## Motivation and Context

This fixes issue https://github.com/jsonnet-bundler/jsonnet-bundler/issues/64, which has been open for a while. Essentially, it enables `jsonnet-bundler` to be packaged more easily so it can be distributed amongst the main channels, i.e. Docker, Homebrew, etc. 

## Items to Address

### Generic questions

1. Should GoReleaser be triggered automatically by Drone on a `tag` push, or should a maintainer perform the releasing manually?
2. Are Docker images wanted? See **Docker registry** below.
3. Is a Homebrew formula wanted? See **Homebrew formula** below.
4. What artifacts should be attached to the GitHub release? Binaries only? Archives only? Both? See **GitHub releases**.

### Docker registry

In order for this to be merged, the repository maintainers should decide _**where**_ to put Docker images, if at all. If it's desired to not have Docker images generated, that's also possible. If it's decided that this is wanted, credentials would also need to be generated to push to the Docker registry.

Essentially, the GoReleaser builds tags according to semver specifications. For example, if this project is hosted on DockerHub, the following images would be generated:

- `docker.io/jsonnet-bundler/jb:latest`
- `docker.io/jsonnet-bundler/jb:v0.4.0`
- `docker.io/jsonnet-bundler/jb:v0.4`
- `docker.io/jsonnet-bundler/jb:v0`

Other options are also possible.

### Homebrew formula

In a similar fashion, if it's decided to create Homebrew formulas, the following options are available:

- **Option 1:** Host the Homebrew tap from this repository, which means creating a `Formula` folder at the root.
- **Option 2:** Host the Homebrew tap from another repository in the `jsonnet-bunlder` organization; in which case, a Github token would need to be provided by the maintainers which has access to write to that repository.
- **Option 3:** Don't host any Homebrew tap, and later manually create a formula in the https://github.com/Homebrew/homebrew-core repository.

### GitHub releases

Currently the `jb` binary is added to GitHub releases directly without packaging. This is also possible with GoReleaser in the exact same way, but **if Homebrew is being used as well**, then Homebrew _**needs**_ archives to be built. In other words, Homebrew does not download binaries directly; it always first downloads an archive, and then extracts it.

Coupled with the Homebrew options above are the following options for GitHub releases:

- **Option 1:** Don't use Homebrew at all; attach binaries to the GitHub release as it happens right now.
- **Option 2:** Use Homebrew in some way; attach archives only to the GitHub release.
- **Option 3:** Use Homebrew in some way; attach both archives and binaries to the GitHub release, and let people choose.

## How Has This Been Tested?

To test locally, you can either run `goreleaser --rm-dist --skip-publish --snapshot` or `make cross`; they do the same thing, in the end.

Someone who has write access to this repository should probably do more testing related to releases in order to make sure it works.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.