### PR TITLE
update readme so install method works for Go 1.17+ too

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The jsonnet-bundler is a package manager for [Jsonnet](http://jsonnet.org/).
 ## Install
 
 ```
-GO111MODULE="on" go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
 ```
 **NOTE**: please use a recent Go version to do this, ideally Go 1.13 or greater.
 


### PR DESCRIPTION
fixes #148 