### PR TITLE
Correct path resolution to nested local dependencies

### DIFF
--- a/pkg/local.go
+++ b/pkg/local.go
@@ -38,7 +38,7 @@ func NewLocalPackage(source *deps.Local) Interface {
 func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (lockVersion string, err error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get current working directory: %w")
+		return "", errors.Wrap(err, "failed to get current working directory")
 	}
 
 	oldname := filepath.Join(wd, p.Source.Directory)
@@ -51,17 +51,17 @@ func (p *LocalPackage) Install(ctx context.Context, name, dir, version string) (
 
 	err = os.RemoveAll(newname)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to clean previous destination path: %w")
+		return "", errors.Wrap(err, "failed to clean previous destination path")
 	}
 
 	_, err = os.Stat(oldname)
 	if os.IsNotExist(err) {
-		return "", errors.Wrap(err, "symlink destination path does not exist: %w")
+		return "", errors.Wrap(err, "symlink destination path does not exist")
 	}
 
 	err = os.Symlink(linkname, newname)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create symlink for local dependency: %w")
+		return "", errors.Wrap(err, "failed to create symlink for local dependency")
 	}
 
 	color.Magenta("LOCAL %s -> %s", name, oldname)


### PR DESCRIPTION
The tool failed to properly resolve nested local dependencies to jsonnet
bundles in different directory trees. This arises because the
installation command resolves and installs nested jsonnet local
dependencies relative to the root jsonnetfile, rather than track and
evaluate the installation path relative to the nested library's
jsonnetfile.

Consider a repository with multiple local jsonnet bundles in various
directory trees, organised as follows (lockfiles elided for brevity):

```
  /top/of/tree
   |- lib/module_A
     |- jsonnetfile.json
   |- lib/module_B
     |- jsonnetfile.json
   |- src/root_module
     |- jsonnetfile.json
```

The modules depend on each other as follows:

<pre>
  ┌───────────────────┐   ┌───────────────────┐   ┌───────────────────┐
  │                   │   │                   │   │                   │
  │  src/root_module  │──▶│   lib/module_A    │──▶│   lib/module_B    │
  │                   │   │                   │   │                   │
  └───────────────────┘   └───────────────────┘   └───────────────────┘
</pre>

where `X ──▶ Y` indicates bundle X depends on bundle Y, expressed by
expressing a dependency of type local in bundle X's jsonnetfile.json,
whose path is the relative path from bundle X to bundle Y in the
directory structure. For example, src/root_module will express a
local dependency on path ../lib/module_A to depend on library module A.

Invoking jb install in src/root_module will result in an error:

<pre>
  jb: error: failed to install packages: downloading: symlink destination path does not exist: %w:
    stat /top/of/tree/src/module_B: no such file or directory
</pre>

This occurs because jsonnet-bundler improperly attempts to resolve the
nested dependency on library module B relative to the root module path,
i.e. src/root_module.  The correct behaviour is to perform such
resolution relative to the depending module's jsonnetfile.json, i.e.
relative to lib/module_A.

An example repo that demonstrates the behaviour can be found in
https://github.com/mhuxtable/jb_local_nested_dep_example.