### PR TITLE
Support Bitbucket personal repositories

### DIFF
--- a/spec/v1/deps/git.go
+++ b/spec/v1/deps/git.go
@@ -106,8 +106,8 @@ const (
 	gitSSHExp = `ssh://git@(?P<host>.+)/(?P<user>.+)/(?P<repo>.+).git`
 	gitSCPExp = `^git@(?P<host>.+):(?P<user>.+)/(?P<repo>.+).git`
 	// The long ugly pattern for ${host} here is a generic pattern for "valid URL with zero or more subdomains and a valid TLD"
-	gitHTTPSSubgroup = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9/\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)\.git`
-	gitHTTPSExp      = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)`
+	gitHTTPSSubgroup = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_~a-zA-Z0-9/\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)\.git`
+	gitHTTPSExp      = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_~a-zA-Z0-9\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)`
 )
 
 var (

--- a/spec/v1/deps/git_test.go
+++ b/spec/v1/deps/git_test.go
@@ -220,6 +220,23 @@ func TestParseGit(t *testing.T) {
 			},
 			wantRemote: "https://example.com/group/subgroup/repository.git",
 		},
+		{
+			name: "ValidBitbucketPersonalRepository",
+			uri:  "bitbucket.org/~user/repository.git",
+			want: &Dependency{
+				Version: "master",
+				Source: Source{
+					GitSource: &Git{
+						Scheme: GitSchemeHTTPS,
+						Host:   "bitbucket.org",
+						User:   "~user",
+						Repo:   "repository",
+						Subdir: "",
+					},
+				},
+			},
+			wantRemote: "https://bitbucket.org/~user/repository.git",
+		},
 	}
 
 	for _, c := range tests {


### PR DESCRIPTION
Opening this one to enable Bitbucket Server private repositories

> user's slug prefixed by tilde as the project key 
https://confluence.atlassian.com/bitbucketserverkb/personal-projects-in-bitbucket-server-1072204133.html

Related to _Support other hosts than GitHub for https_ #72