### PR TITLE
feat(install): add --legacy-name flag

### DIFF
--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -17,6 +17,7 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -30,7 +31,7 @@ import (
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
 )
 
-func installCommand(dir, jsonnetHome string, uris []string, single bool) int {
+func installCommand(dir, jsonnetHome string, uris []string, single bool, legacyName string) int {
 	if dir == "" {
 		dir = "."
 	}
@@ -53,6 +54,10 @@ func installCommand(dir, jsonnetHome string, uris []string, single bool) int {
 		os.MkdirAll(filepath.Join(dir, jsonnetHome, ".tmp"), os.ModePerm),
 		"creating vendor folder")
 
+	if len(uris) > 1 && legacyName != "" {
+		log.Fatal("Cannot use --legacy-name with mutliple uris")
+	}
+
 	for _, u := range uris {
 		d := deps.Parse(dir, u)
 		if d == nil {
@@ -61,6 +66,10 @@ func installCommand(dir, jsonnetHome string, uris []string, single bool) int {
 
 		if single {
 			d.Single = true
+		}
+
+		if legacyName != "" {
+			d.LegacyNameCompat = legacyName
 		}
 
 		if !depEqual(jsonnetFile.Dependencies[d.Name()], *d) {

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -59,6 +59,7 @@ func Main() int {
 	installCmd := a.Command(installActionName, "Install new dependencies. Existing ones are silently skipped")
 	installCmdURIs := installCmd.Arg("uris", "URIs to packages to install, URLs or file paths").Strings()
 	installCmdSingle := installCmd.Flag("single", "install package without dependencies").Short('1').Bool()
+	installCmdLegacyName := installCmd.Flag("legacy-name", "set legacy name").String()
 
 	updateCmd := a.Command(updateActionName, "Update all or specific dependencies.")
 	updateCmdURIs := updateCmd.Arg("uris", "URIs to packages to update, URLs or file paths").Strings()
@@ -83,13 +84,13 @@ func Main() int {
 	case initCmd.FullCommand():
 		return initCommand(workdir)
 	case installCmd.FullCommand():
-		return installCommand(workdir, cfg.JsonnetHome, *installCmdURIs, *installCmdSingle)
+		return installCommand(workdir, cfg.JsonnetHome, *installCmdURIs, *installCmdSingle, *installCmdLegacyName)
 	case updateCmd.FullCommand():
 		return updateCommand(workdir, cfg.JsonnetHome, *updateCmdURIs)
 	case rewriteCmd.FullCommand():
 		return rewriteCommand(workdir, cfg.JsonnetHome)
 	default:
-		installCommand(workdir, cfg.JsonnetHome, []string{}, false)
+		installCommand(workdir, cfg.JsonnetHome, []string{}, false, "")
 	}
 
 	return 0


### PR DESCRIPTION
Unfortunately the legacyImport feature is still wide-spread, this causes conflicts
occasionally. This flag provides a user-friendly fix to workaround these conflicts.