### PR TITLE
Add arm64 to MacOS binary compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ cross: clean
 	  -output="$(OUT_DIR)/jb-{{.OS}}-{{.Arch}}" \
 	  -ldflags=$(LDFLAGS) \
 	  -arch="amd64 arm64 arm" -os="linux" \
-	  -osarch="darwin/amd64" \
+	  -arch="amd64 arm64" -os="darwin" \
 	  -osarch="windows/amd64" \
 	  ./cmd/$(BIN)
 


### PR DESCRIPTION
I would like to use my new Mac with the packaged releases of jsonnet-bundler. Instead of opening an issue, I thought it would be easier to open a PR to address it. 