### PR TITLE
feat(cmd/init): add flag to disable legacy imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Commands:
   help [<command>...]
     Show help.
 
-  init
+  init [<flags>]
     Initialize a new empty jsonnetfile
 
   install [<flags>] [<uris>...]

--- a/cmd/jb/init.go
+++ b/cmd/jb/init.go
@@ -25,7 +25,7 @@ import (
 	v1 "github.com/jsonnet-bundler/jsonnet-bundler/spec/v1"
 )
 
-func initCommand(dir string) int {
+func initCommand(dir string, legacyImports bool) int {
 	exists, err := jsonnetfile.Exists(jsonnetfile.File)
 	kingpin.FatalIfError(err, "Failed to check for jsonnetfile.json")
 
@@ -35,8 +35,9 @@ func initCommand(dir string) int {
 	}
 
 	s := v1.New()
+
 	// TODO: disable them by default eventually
-	// s.LegacyImports = false
+	s.LegacyImports = legacyImports
 
 	contents, err := json.MarshalIndent(s, "", "  ")
 	kingpin.FatalIfError(err, "formatting jsonnetfile contents as json")

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -55,6 +55,7 @@ func Main() int {
 		Short('q').BoolVar(&pkg.GitQuiet)
 
 	initCmd := a.Command(initActionName, "Initialize a new empty jsonnetfile")
+	initCmdLegacyImports := initCmd.Flag("legacy-imports", "use legacy imports").Default("true").Bool()
 
 	installCmd := a.Command(installActionName, "Install new dependencies. Existing ones are silently skipped")
 	installCmdURIs := installCmd.Arg("uris", "URIs to packages to install, URLs or file paths").Strings()
@@ -82,7 +83,7 @@ func Main() int {
 
 	switch command {
 	case initCmd.FullCommand():
-		return initCommand(workdir)
+		return initCommand(workdir, *initCmdLegacyImports)
 	case installCmd.FullCommand():
 		return installCommand(workdir, cfg.JsonnetHome, *installCmdURIs, *installCmdSingle, *installCmdLegacyName)
 	case updateCmd.FullCommand():


### PR DESCRIPTION
This PR gives the user the ability to disable legacy imports on init:

```
jb init --no-legacy-imports
```

In a recent project I wanted to disable legacy imports on a dependency, but if the user
does `jb init` it defaults to enable it and the flag on the dependency is ignored. This
flag will help us guide users to use absolute imports.