### PR TITLE
Feature: add caching of downloaded archives

### DIFF
--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -201,6 +201,11 @@ func checkLegacyNameTaken(legacyName string, pkgName string) (bool, error) {
 
 func known(deps map[string]deps.Dependency, p string) bool {
 	p = filepath.ToSlash(p)
+
+	if strings.HasPrefix(p, "cache") {
+		return true
+	}
+
 	for _, d := range deps {
 		k := filepath.ToSlash(d.Name())
 		if strings.HasPrefix(p, k) || strings.HasPrefix(k, p) {


### PR DESCRIPTION
Fix for #173: this PR adds a file cache for downloaded archives such that subsequent calls to `jb update` do not require re-downloading the archive of the dependent repository.

This is a first draft to gather feedback.