### PR TITLE
Disable legacy imports by default

### DIFF
--- a/spec/v1/spec.go
+++ b/spec/v1/spec.go
@@ -37,7 +37,7 @@ type JsonnetFile struct {
 func New() JsonnetFile {
 	return JsonnetFile{
 		Dependencies:  make(map[string]deps.Dependency),
-		LegacyImports: true,
+		LegacyImports: false,
 	}
 }
 


### PR DESCRIPTION
It's been almost 4 years. Let's disable the legacy imports by default.
They can still be enabled if needed.
