### PR TITLE
Allow getting source archive from private repo

### DIFF
--- a/pkg/git.go
+++ b/pkg/git.go
@@ -52,7 +52,20 @@ var GitQuiet = false
 
 func downloadGitHubArchive(filepath string, url string) error {
 	// Get the data
-	resp, err := http.Get(url)
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", url, nil)
+	token_env_vars := []string{"GITHUB_TOKEN", "GH_TOKEN", "GIT_TOKEN"}
+	token := ""
+
+	for i := 0; token == "" && i < len(token_env_vars); i++ {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+
+	if token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Running jb install under a GitHub Action will fail to install jsonnet packages from a private git repository.

This PR aims to fix that by applying standard environment variables to the authorization header for the http get request to download the archive source from the target repository.

It will add authorization bearer token header when any of the following environment variables are set (in order of precedence)

- GITHUB_TOKEN
- GH_TOKEN
- GIT_TOKEN
