### PR TITLE
feat: add basic registry support

### DIFF
--- a/cmd/jb/registry.go
+++ b/cmd/jb/registry.go
@@ -1,0 +1,130 @@
+// Copyright 2018 jsonnet-bundler authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/jsonnet-bundler/jsonnet-bundler/pkg"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func registryAddCommand(name, description, url, filename string) int {
+	registry := pkg.NewGitRegistry(name, description, url, filename)
+
+	for _, r := range pkg.Registries.Entries {
+		if r.Name == name {
+			kingpin.Fatalf("Registry %s already exists", name)
+		}
+	}
+
+	pkg.Registries.Entries = append(pkg.Registries.Entries, *registry)
+
+	err := registry.Init(context.TODO())
+	if err != nil {
+		kingpin.FatalIfError(err, "could not init registry")
+	}
+	err = registry.Update(context.TODO())
+	if err != nil {
+		kingpin.FatalIfError(err, "could not update registry")
+	}
+	return 0
+}
+
+func registryRemoveCommand(name string) int {
+	var notRemoved []pkg.GitRegistry
+	var err error
+
+	for _, r := range pkg.Registries.Entries {
+		if r.Name != name {
+			notRemoved = append(notRemoved, r)
+		} else {
+			err = r.CleanCache()
+			if err != nil {
+				kingpin.FatalIfError(err, "could not clean cache files of registry %s", r.Name)
+			}
+		}
+	}
+	pkg.Registries.Entries = notRemoved
+	pkg.Registries.SaveRegistries()
+
+	return 0
+}
+
+func registryUpdateCommand() int {
+	err := pkg.UpdateRegistries(context.TODO())
+	if err != nil {
+		kingpin.FatalIfError(err, "could not update registry")
+	}
+	return 0
+}
+
+func registryListCommand() int {
+	w := tabwriter.NewWriter(os.Stdout, 1, 1, 5, ' ', 0)
+	pkg.PrintHeader(w, []string{"Name", "Description", "Source"})
+
+	for _, registry := range pkg.Registries.Entries {
+		pkg.PrintRow(w, []string{registry.Name, registry.Description, registry.Source})
+	}
+	w.Flush()
+	return 0
+}
+
+func registrySearchCommand(query string, details, allVersions bool) int {
+	results, err := pkg.SearchPackage(context.TODO(), query)
+	if err != nil {
+		kingpin.FatalIfError(err, "could not search package")
+	}
+
+	var w *tabwriter.Writer
+
+	if details {
+		w = tabwriter.NewWriter(os.Stdout, 1, 1, 5, ' ', 0)
+		pkg.PrintHeader(w, []string{"Name", "Description", "Registry", "Versions"})
+	} else if allVersions {
+		w = tabwriter.NewWriter(os.Stdout, 1, 1, 5, ' ', 0)
+		pkg.PrintHeader(w, []string{"Name", "Version", "Url"})
+	} else {
+		w = tabwriter.NewWriter(os.Stdout, 1, 1, 5, ' ', 0)
+		pkg.PrintHeader(w, []string{"Name", "Url"})
+	}
+
+	for registryName, packages := range results {
+		if len(packages) > 0 {
+			for _, p := range packages {
+				sort.Sort(p.Versions)
+				if details {
+					versions := []string{}
+					for _, v := range p.Versions {
+						versions = append(versions, v.Version)
+					}
+					pkg.PrintRow(w, []string{p.Name, p.Description, registryName, strings.Join(versions, ",")})
+				} else if allVersions {
+					for _, v := range p.Versions {
+						pkg.PrintRow(w, []string{p.Name, v.Version, v.Source})
+					}
+				} else {
+					pkg.PrintRow(w, []string{p.Name, p.Versions[len(p.Versions)-1].Source})
+				}
+			}
+		}
+	}
+	w.Flush()
+	return 0
+}

--- a/cmd/jb/registry.go
+++ b/cmd/jb/registry.go
@@ -35,8 +35,12 @@ func registryAddCommand(name, description, url, filename string) int {
 	}
 
 	pkg.Registries.Entries = append(pkg.Registries.Entries, *registry)
+	err := pkg.Registries.SaveRegistries()
+	if err != nil {
+		kingpin.FatalIfError(err, "could not save registry")
+	}
 
-	err := registry.Init(context.TODO())
+	err = registry.Init(context.TODO())
 	if err != nil {
 		kingpin.FatalIfError(err, "could not init registry")
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,6 @@ require (
 	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,0 +1,85 @@
+package pkg
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
+const RegistryFile = "~/.config/jsonnet-bundler/registries.yaml"
+
+var Registries *RegistryConfig
+
+type RegistryConfig struct {
+	// Dir is the path where the registry config(s) are stored
+	Entries []GitRegistry `yaml:"registries"`
+}
+
+func DefaultConfig() *RegistryConfig {
+	return &RegistryConfig{
+		Entries: []GitRegistry{
+			{
+				Name:        "Default",
+				Description: "The default registry.",
+				Source:      "https://github.com/dadav/jb-registry-example.git",
+				PackageFile: "_gen.json",
+			},
+		},
+	}
+}
+
+func expandTilde(path string) (string, error) {
+	if len(path) > 0 && path[0] == '~' {
+		usr, err := user.Current()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(usr.HomeDir, path[1:]), nil
+	}
+	return path, nil
+}
+
+func (c RegistryConfig) SaveRegistries() error {
+	confFile, err := expandTilde(RegistryFile)
+	if err != nil {
+		return err
+	}
+	yamlData, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(filepath.Dir(confFile), os.ModePerm)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(confFile, yamlData, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func LoadRegistries() error {
+	confFile, err := expandTilde(RegistryFile)
+	if err != nil {
+		return err
+	}
+	fileContent, err := os.ReadFile(confFile)
+	if err != nil {
+		Registries = DefaultConfig()
+		err := Registries.SaveRegistries()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	err = yaml.Unmarshal(fileContent, &Registries)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/registry.go
+++ b/pkg/registry.go
@@ -1,0 +1,251 @@
+package pkg
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Version describes a specific version of a package
+type Version struct {
+	Version string `json:"version"`
+	Source  string `json:"source"`
+}
+
+type Versions []Version
+
+// Package describes a package referenced in a registry
+type Package struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Source      string   `json:"source"`
+	Versions    Versions `json:"versions"`
+}
+
+// GitRegistry implements the Registry interface and supports registries in git
+type GitRegistry struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Source      string `yaml:"source"`
+	PackageFile string `yaml:"filename"`
+}
+
+// NewGitRegistry creates an instance of GitRegistry
+func NewGitRegistry(name, description, source, packageFile string) *GitRegistry {
+	return &GitRegistry{
+		Name:        name,
+		Description: description,
+		Source:      source,
+		PackageFile: packageFile,
+	}
+}
+
+func (v Versions) Len() int {
+	return len(v)
+}
+
+func (v Versions) Less(i, j int) bool {
+	// Split version strings into parts based on dots.
+	partsA := strings.Split(v[i].Version, ".")
+	partsB := strings.Split(v[j].Version, ".")
+
+	// Compare each part of the version strings.
+	for k := 0; k < len(partsA) && k < len(partsB); k++ {
+
+		// Convert parts to integers for numerical comparison.
+		numA, errA := strconv.Atoi(partsA[k])
+		numB, errB := strconv.Atoi(partsB[k])
+
+		// If conversion fails, fall back to lexicographical comparison.
+		if errA == nil && errB == nil {
+			if numA < numB {
+				return true
+			} else if numA > numB {
+				return false
+			}
+		} else {
+			if partsA[k] < partsB[k] {
+				return true
+			} else if partsA[k] > partsB[k] {
+				return false
+			}
+		}
+	}
+
+	// If all common parts are equal, the shorter version string should come first.
+	return len(partsA) < len(partsB)
+}
+
+// Swap swaps the elements with indexes i and j.
+func (v Versions) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func (r GitRegistry) normalizeName() string {
+	cleanName := filepath.Clean(r.Name)
+	return strings.ToLower(cleanName)
+}
+
+func (r GitRegistry) getCacheDir(create bool) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	cacheDir := filepath.Join(homeDir, ".cache", "jsonnet-bundler", "registries", r.normalizeName())
+	if create {
+		err = os.MkdirAll(cacheDir, os.ModePerm)
+		if err != nil {
+			return "", err
+		}
+
+	}
+
+	return cacheDir, nil
+}
+
+func (r GitRegistry) CleanCache() error {
+	cacheDir, err := r.getCacheDir(false)
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(cacheDir)
+}
+
+func (r GitRegistry) run(ctx context.Context, args ...string) (string, error) {
+	cacheDir, err := r.getCacheDir(true)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = cacheDir
+	cmd.Stderr = nil
+	output, err := cmd.Output()
+	return strings.TrimSpace(string(output)), err
+}
+
+func (r GitRegistry) Init(ctx context.Context) error {
+	cacheDir, err := r.getCacheDir(true)
+	if err != nil {
+		return err
+	}
+	_, err = os.Stat(filepath.Join(cacheDir, ".git"))
+	if err == nil {
+		// already initialized
+		return nil
+	} else if !os.IsNotExist(err) {
+		// some fs error
+		return err
+	}
+	// file not found, start init process
+	_, err = r.run(ctx, "init")
+	if err != nil {
+		return err
+	}
+	_, err = r.run(ctx, "remote", "add", "origin", r.Source)
+	if err != nil {
+		return err
+	}
+	_, err = r.run(ctx, "sparse-checkout", "set", "--skip-checks", r.PackageFile)
+	if err != nil {
+		return err
+	}
+	_, err = r.run(ctx, "fetch", "--filter=blob:none", "--depth=1")
+	if err != nil {
+		return err
+	}
+
+	output, err := r.run(ctx, "symbolic-ref", "HEAD")
+	if err != nil {
+		return err
+	}
+
+	parts := strings.Split(output, "/")
+	branch := parts[len(parts)-1]
+
+	_, err = r.run(ctx, "checkout", branch)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Update to latest version
+func (r GitRegistry) Update(ctx context.Context) error {
+	_, err := r.run(ctx, "pull")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Search queries the data for some text
+func (r GitRegistry) Search(ctx context.Context, query string) ([]Package, error) {
+	cacheDir, err := r.getCacheDir(true)
+	if err != nil {
+		return nil, err
+	}
+	fileContent, err := os.ReadFile(filepath.Join(cacheDir, r.PackageFile))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create an instance of the struct to hold the data
+	var entries []Package
+
+	// Unmarshal the JSON data into the struct
+	err = json.Unmarshal(fileContent, &entries)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := []Package{}
+
+	q := strings.ToLower(query)
+	for _, item := range entries {
+		if strings.Contains(strings.ToLower(item.Name), q) || strings.Contains(strings.ToLower(item.Description), q) {
+			filtered = append(filtered, item)
+		}
+	}
+
+	return filtered, nil
+}
+
+func UpdateRegistries(ctx context.Context) error {
+	for _, registry := range Registries.Entries {
+		err := registry.Init(ctx)
+		if err != nil {
+			return err
+		}
+		err = registry.Update(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func SearchPackage(ctx context.Context, query string) (map[string][]Package, error) {
+	results := make(map[string][]Package)
+
+	for _, registry := range Registries.Entries {
+		err := registry.Init(ctx)
+		if err != nil {
+			return nil, err
+		}
+		result, err := registry.Search(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		results[registry.Name] = result
+	}
+
+	return results, nil
+}

--- a/pkg/table.go
+++ b/pkg/table.go
@@ -1,0 +1,24 @@
+package pkg
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+func PrintRow(writer io.Writer, line []string) {
+	fmt.Fprintln(writer, strings.Join(line, "\t"))
+}
+
+func PrintHeader(writer io.Writer, headers []string) {
+	PrintRow(writer, headers)
+	PrintRow(writer, replaceRow(headers))
+}
+
+func replaceRow(row []string) []string {
+	replaced := make([]string, len(row))
+	for i, v := range row {
+		replaced[i] = strings.Repeat("-", len(v))
+	}
+	return replaced
+}


### PR DESCRIPTION
This PR introduces the `registry` command with some more subcommands.

The user can use this subcommand to search for packages in the configured registries.

A registry is a git repository like this example: https://github.com/dadav/jb-registry-example

It contains an `index.yaml` with the libsonnet repositories and a script `update.py` which is run daily to update the versions. The result is written into `_gen.json` which will be used by the introduced commands to show the user the available packages.

Examples:

```bash
go run ./cmd/jb registry list  
Name        Description               Source
----        -----------               ------
Default     The default registry.     https://github.com/dadav/jb-registry-example.git
```

```bash
go run ./cmd/jb registry search       
Name                                 Url
----                                 ---
argo-cd-libsonnet                    https://github.com/jsonnet-libs/argo-cd-libsonnet/2.7@main
istio-libsonnet                      https://github.com/jsonnet-libs/istio-libsonnet/1.20@main
k8s-libsonnet                        https://github.com/jsonnet-libs/k8s-libsonnet/1.28@main
keda-libsonnet                       https://github.com/jsonnet-libs/keda-libsonnet/2.12@main
teleport-operator-libsonnet          https://github.com/jsonnet-libs/teleport-operator-libsonnet/14.1@main
vault-secrets-operator-libsonnet     https://github.com/jsonnet-libs/vault-secrets-operator-libsonnet/0.3.0@main
```

```bash
go run ./cmd/jb registry search k8s -a
Name              Version     Url
----              -------     ---
k8s-libsonnet     1.20        https://github.com/jsonnet-libs/k8s-libsonnet/1.20@main
k8s-libsonnet     1.21        https://github.com/jsonnet-libs/k8s-libsonnet/1.21@main
k8s-libsonnet     1.22        https://github.com/jsonnet-libs/k8s-libsonnet/1.22@main
k8s-libsonnet     1.23        https://github.com/jsonnet-libs/k8s-libsonnet/1.23@main
k8s-libsonnet     1.24        https://github.com/jsonnet-libs/k8s-libsonnet/1.24@main
k8s-libsonnet     1.25        https://github.com/jsonnet-libs/k8s-libsonnet/1.25@main
k8s-libsonnet     1.26        https://github.com/jsonnet-libs/k8s-libsonnet/1.26@main
k8s-libsonnet     1.27        https://github.com/jsonnet-libs/k8s-libsonnet/1.27@main
k8s-libsonnet     1.28        https://github.com/jsonnet-libs/k8s-libsonnet/1.28@main
```