### PR TITLE
Allow jsonnetpkg-home absolute paths

### DIFF
--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -51,7 +51,7 @@ func installCommand(dir, jsonnetHome string, uris []string, single bool, legacyN
 	kingpin.FatalIfError(err, "")
 
 	kingpin.FatalIfError(
-		os.MkdirAll(filepath.Join(dir, jsonnetHome, ".tmp"), os.ModePerm),
+		os.MkdirAll(filepath.Join(jsonnetHome, ".tmp"), os.ModePerm),
 		"creating vendor folder")
 
 	if len(uris) > 1 && legacyName != "" {
@@ -81,8 +81,7 @@ func installCommand(dir, jsonnetHome string, uris []string, single bool, legacyN
 		}
 	}
 
-	jsonnetPkgHomeDir := filepath.Join(dir, jsonnetHome)
-	locked, err := pkg.Ensure(jsonnetFile, jsonnetPkgHomeDir, lockFile.Dependencies)
+	locked, err := pkg.Ensure(jsonnetFile, jsonnetHome, lockFile.Dependencies)
 	kingpin.FatalIfError(err, "failed to install packages")
 
 	pkg.CleanLegacyName(jsonnetFile.Dependencies)

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -78,7 +78,11 @@ func Main() int {
 		return 1
 	}
 
-	cfg.JsonnetHome = filepath.Clean(cfg.JsonnetHome)
+	jh := filepath.Clean(cfg.JsonnetHome)
+	if !filepath.IsAbs(jh) {
+		jh = filepath.Join(workdir, jh)
+	}
+	cfg.JsonnetHome = jh
 
 	switch command {
 	case initCmd.FullCommand():

--- a/cmd/jb/rewrite.go
+++ b/cmd/jb/rewrite.go
@@ -22,13 +22,13 @@ import (
 	"github.com/jsonnet-bundler/jsonnet-bundler/tool/rewrite"
 )
 
-func rewriteCommand(dir, vendorDir string) int {
+func rewriteCommand(dir, jsonnetHome string) int {
 	locks, err := jsonnetfile.Load(filepath.Join(dir, jsonnetfile.LockFile))
 	if err != nil {
 		kingpin.Fatalf("Failed to load lockFile: %s.\nThe locks are required to compute the new import names. Make sure to run `jb install` first.", err)
 	}
 
-	if err := rewrite.Rewrite(dir, vendorDir, locks.Dependencies); err != nil {
+	if err := rewrite.Rewrite(dir, jsonnetHome, locks.Dependencies); err != nil {
 		kingpin.FatalIfError(err, "")
 	}
 

--- a/cmd/jb/update.go
+++ b/cmd/jb/update.go
@@ -39,7 +39,7 @@ func updateCommand(dir, jsonnetHome string, uris []string) int {
 	kingpin.FatalIfError(err, "failed to load lockfile")
 
 	kingpin.FatalIfError(
-		os.MkdirAll(filepath.Join(dir, jsonnetHome, ".tmp"), os.ModePerm),
+		os.MkdirAll(filepath.Join(jsonnetHome, ".tmp"), os.ModePerm),
 		"creating vendor folder")
 
 	locks := lockFile.Dependencies
@@ -58,7 +58,7 @@ func updateCommand(dir, jsonnetHome string, uris []string) int {
 		locks = make(map[string]deps.Dependency)
 	}
 
-	newLocks, err := pkg.Ensure(jsonnetFile, filepath.Join(dir, jsonnetHome), locks)
+	newLocks, err := pkg.Ensure(jsonnetFile, jsonnetHome, locks)
 	kingpin.FatalIfError(err, "updating")
 
 	kingpin.FatalIfError(

--- a/tool/rewrite/rewrite.go
+++ b/tool/rewrite/rewrite.go
@@ -31,7 +31,7 @@ var expr = regexp.MustCompile(`(?mU)(import ["'])(.*)(\/.*["'])`)
 
 // Rewrite changes all imports in `dir` from legacy to absolute style
 // All files in `vendorDir` are ignored
-func Rewrite(dir, vendorDir string, packages map[string]deps.Dependency) error {
+func Rewrite(dir, jsonnetHome string, packages map[string]deps.Dependency) error {
 	imports := make(map[string]string)
 	for _, p := range packages {
 		if p.LegacyName() == p.Name() {
@@ -41,7 +41,7 @@ func Rewrite(dir, vendorDir string, packages map[string]deps.Dependency) error {
 		imports[p.LegacyName()] = p.Name()
 	}
 
-	vendorFi, err := os.Stat(filepath.Join(dir, vendorDir))
+	vendorFi, err := os.Stat(jsonnetHome)
 	if err != nil {
 		return err
 	}

--- a/tool/rewrite/rewrite_test.go
+++ b/tool/rewrite/rewrite_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -68,8 +68,8 @@ func testRewriteWithJsonnetHome(t *testing.T, jsonnetHome string) {
 	err = ioutil.WriteFile(name, []byte(sample), 0644)
 	require.Nil(t, err)
 
-	vendorDir := filepath.Join(dir, jsonnetHome)
-	err = os.MkdirAll(vendorDir, os.ModePerm)
+	jsonnetHome = filepath.Join(dir, jsonnetHome)
+	err = os.MkdirAll(jsonnetHome, os.ModePerm)
 	require.Nil(t, err)
 
 	err = Rewrite(dir, jsonnetHome, locks)


### PR DESCRIPTION
This allows you to provide an absolute path to `--jsonnetpkg-home` to install vendor dependencies outside of the current root directory. I've updated how the `jsonnetHome` path is handled by making it an absolute path before passing it around to the different commands.

Fixes #152