### PR TITLE
docs: add uri example and usage for install command

### DIFF
--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -57,7 +57,10 @@ func Main() int {
 	initCmd := a.Command(initActionName, "Initialize a new empty jsonnetfile")
 
 	installCmd := a.Command(installActionName, "Install new dependencies. Existing ones are silently skipped")
-	installCmdURIs := installCmd.Arg("uris", "URIs to packages to install, URLs or file paths").Strings()
+	installCmdURIs := installCmd.Arg("uris", "URIs to packages to install, URLs, or file paths."+
+		" The subpath can be assigned by `/subpath`."+
+		" The version can be assigned by `@ref`."+
+		" e.g. https://github.com/jsonnet-libs/k8s-libsonnet/1.30@main").Strings()
 	installCmdSingle := installCmd.Flag("single", "install package without dependencies").Short('1').Bool()
 	installCmdLegacyName := installCmd.Flag("legacy-name", "set legacy name").String()
 


### PR DESCRIPTION
It is better to provide instructions on defining the subpath and the version when installing a package.

The new help message looks like this:

```shell
$ jb install --help
usage: jb.exe install [<flags>] [<uris>...]

Install new dependencies. Existing ones are silently skipped

Flags:
  -h, --help                     Show context-sensitive help (also try
                                 --help-long and --help-man).
      --version                  Show application version.
      --jsonnetpkg-home="vendor"
                                 The directory used to cache packages in.
  -q, --quiet                    Suppress any output from git command.
  -1, --single                   install package without dependencies
      --legacy-name=LEGACY-NAME  set legacy name

Args:
  [<uris>]  URIs to packages to install, URLs, or file paths. The subpath can be
            assigned by `/subpath`. The version can be assigned by `@ref`. e.g.
            https://github.com/jsonnet-libs/k8s-libsonnet/1.30@main
```