### PR TITLE
Add support for Azure DevOps based on #126

### DIFF
--- a/cmd/jb/main_test.go
+++ b/cmd/jb/main_test.go
@@ -63,6 +63,22 @@ func TestParseDependency(t *testing.T) {
 			},
 		},
 		{
+			name: "AzureGitHTTPS",
+			path: "dev.azure.com/microsoft/engineering/_git/libraries/my-libsonnet@v1.0.0",
+			want: &deps.Dependency{
+				Source: deps.Source{
+					GitSource: &deps.Git{
+						Scheme: deps.GitSchemeHTTPSAzureDevops,
+						Host:   "dev.azure.com",
+						User:   "microsoft/engineering/_git",
+						Repo:   "libraries",
+						Subdir: "/my-libsonnet",
+					},
+				},
+				Version: "v1.0.0",
+			},
+		},
+		{
 			name: "SSH",
 			path: "git+ssh://git@github.com/jsonnet-bundler/jsonnet-bundler.git",
 			want: &deps.Dependency{

--- a/spec/v1/deps/git.go
+++ b/spec/v1/deps/git.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	GitSchemeSSH   = "ssh://git@"
-	GitSchemeHTTPS = "https://"
+	GitSchemeSSH              = "ssh://git@"
+	GitSchemeHTTPS            = "https://"
+	GitSchemeHTTPSAzureDevops = "https://dev.azure.com"
 )
 
 // Git holds all required information for cloning a package from git
@@ -90,8 +91,9 @@ func (gs *Git) LegacyName() string {
 }
 
 var gitProtoFmts = map[string]string{
-	GitSchemeSSH:   GitSchemeSSH + "%s/%s/%s.git",
-	GitSchemeHTTPS: GitSchemeHTTPS + "%s/%s/%s.git",
+	GitSchemeSSH:              GitSchemeSSH + "%s/%s/%s.git",
+	GitSchemeHTTPS:            GitSchemeHTTPS + "%s/%s/%s.git",
+	GitSchemeHTTPSAzureDevops: GitSchemeHTTPS + "%s/%s/%s",
 }
 
 // Remote returns a remote string that can be passed to git
@@ -106,8 +108,9 @@ const (
 	gitSSHExp = `ssh://git@(?P<host>.+)/(?P<user>.+)/(?P<repo>.+).git`
 	gitSCPExp = `^git@(?P<host>.+):(?P<user>.+)/(?P<repo>.+).git`
 	// The long ugly pattern for ${host} here is a generic pattern for "valid URL with zero or more subdomains and a valid TLD"
-	gitHTTPSSubgroup = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_~a-zA-Z0-9/\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)\.git`
-	gitHTTPSExp      = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_~a-zA-Z0-9\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)`
+	gitHTTPSSubgroup       = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_~a-zA-Z0-9/\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)\.git`
+	gitHTTPSExp            = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_~a-zA-Z0-9\.]+)/(?P<repo>[-_a-zA-Z0-9\.]+)`
+	gitAzureDevopsHTTPSExp = `(?P<host>[a-zA-Z0-9][a-zA-Z0-9-\.]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})/(?P<user>[-_a-zA-Z0-9/\-\.\s]+/_git)/(?P<repo>[-_a-zA-Z0-9\.]+)`
 )
 
 var (
@@ -131,6 +134,9 @@ func parseGit(uri string) *Dependency {
 	case reMatch(gitSCPExp, uri):
 		gs, version = match(uri, gitSCPExp)
 		gs.Scheme = GitSchemeSSH
+	case reMatch(gitAzureDevopsHTTPSExp, uri):
+		gs, version = match(uri, gitAzureDevopsHTTPSExp)
+		gs.Scheme = GitSchemeHTTPSAzureDevops
 	case reMatch(gitHTTPSSubgroup, uri):
 		gs, version = match(uri, gitHTTPSSubgroup)
 		gs.Scheme = GitSchemeHTTPS


### PR DESCRIPTION
The previous PR for Azure DevOps support went stale, so this reapplies the changeset on top of main from #126.  I've tested this locally for my use-case and it works as expected.

The scheme part feels messy, but I think it'd need a deeper refactor to turn "scheme" into more of a "type."