### PR TITLE
Fix ioutil package deprecation warning

### DIFF
--- a/cmd/jb/init.go
+++ b/cmd/jb/init.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -44,7 +44,7 @@ func initCommand(dir string) int {
 
 	filename := filepath.Join(dir, jsonnetfile.File)
 
-	ioutil.WriteFile(filename, contents, 0644)
+	err = os.WriteFile(filename, contents, 0644)
 	kingpin.FatalIfError(err, "Failed to write new jsonnetfile.json")
 
 	return 0

--- a/cmd/jb/init_test.go
+++ b/cmd/jb/init_test.go
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 //go:build integration
-// +build integration
 
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -26,7 +24,7 @@ import (
 )
 
 func TestInitCommand(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "jb-init")
+	tempDir, err := os.MkdirTemp("", "jb-init")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -36,13 +35,13 @@ func installCommand(dir, jsonnetHome string, uris []string, single bool, legacyN
 		dir = "."
 	}
 
-	jbfilebytes, err := ioutil.ReadFile(filepath.Join(dir, jsonnetfile.File))
+	jbfilebytes, err := os.ReadFile(filepath.Join(dir, jsonnetfile.File))
 	kingpin.FatalIfError(err, "failed to load jsonnetfile")
 
 	jsonnetFile, err := jsonnetfile.Unmarshal(jbfilebytes)
 	kingpin.FatalIfError(err, "")
 
-	jblockfilebytes, err := ioutil.ReadFile(filepath.Join(dir, jsonnetfile.LockFile))
+	jblockfilebytes, err := os.ReadFile(filepath.Join(dir, jsonnetfile.LockFile))
 	if !os.IsNotExist(err) {
 		kingpin.FatalIfError(err, "failed to load lockfile")
 	}
@@ -114,7 +113,7 @@ func writeJSONFile(name string, d interface{}) error {
 	}
 	b = append(b, []byte("\n")...)
 
-	return ioutil.WriteFile(name, b, 0644)
+	return os.WriteFile(name, b, 0644)
 }
 
 func writeChangedJsonnetFile(originalBytes []byte, modified *v1.JsonnetFile, path string) error {

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -13,13 +13,11 @@
 // limitations under the License.
 
 //go:build integration
-// +build integration
 
 package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -119,7 +117,7 @@ func testInstallCommandWithJsonnetHome(t *testing.T, jsonnetHome string) {
 func jsonnetFileContent(t *testing.T, filename string, content []byte) {
 	t.Helper()
 
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	assert.NoError(t, err)
 	if eq := assert.JSONEq(t, string(content), string(bytes)); !eq {
 		t.Log(string(bytes))

--- a/cmd/jb/rewrite.go
+++ b/cmd/jb/rewrite.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/jb/update_test.go
+++ b/cmd/jb/update_test.go
@@ -13,12 +13,10 @@
 // limitations under the License.
 
 //go:build integration
-// +build integration
 
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,10 +44,10 @@ func (rs RepoState) LockPath(dir string) string {
 
 // Write writes this state to dir
 func (rs RepoState) Write(dir string) error {
-	if err := ioutil.WriteFile(rs.FilePath(dir), []byte(rs.File), 0644); err != nil {
+	if err := os.WriteFile(rs.FilePath(dir), []byte(rs.File), 0644); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(rs.LockPath(dir), []byte(rs.Lock), 0644); err != nil {
+	if err := os.WriteFile(rs.LockPath(dir), []byte(rs.Lock), 0644); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(filepath.Join(dir, "vendor/"), os.ModePerm); err != nil {
@@ -60,11 +58,11 @@ func (rs RepoState) Write(dir string) error {
 
 // Assert checks that dir matches this state
 func (rs RepoState) Assert(t *testing.T, dir string) {
-	file, err := ioutil.ReadFile(rs.FilePath(dir))
+	file, err := os.ReadFile(rs.FilePath(dir))
 	require.NoError(t, err)
 	assert.JSONEq(t, rs.File, string(file))
 
-	lock, err := ioutil.ReadFile(rs.LockPath(dir))
+	lock, err := os.ReadFile(rs.LockPath(dir))
 	require.NoError(t, err)
 	assert.JSONEq(t, rs.Lock, string(lock))
 }
@@ -78,7 +76,7 @@ type UpdateCase struct {
 }
 
 func (u UpdateCase) Run(t *testing.T) {
-	dir, err := ioutil.TempDir("", u.name)
+	dir, err := os.MkdirTemp("", u.name)
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -184,7 +183,7 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 
 	pkgh := sha256.Sum256([]byte(fmt.Sprintf("jsonnetpkg-%s-%s", strings.Replace(name, "/", "-", -1), strings.Replace(version, "/", "-", -1))))
 	// using 16 bytes should be a good middle ground between length and collision resistance
-	tmpDir, err := ioutil.TempDir(filepath.Join(dir, ".tmp"), hex.EncodeToString(pkgh[:16]))
+	tmpDir, err := os.MkdirTemp(filepath.Join(dir, ".tmp"), hex.EncodeToString(pkgh[:16]))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create tmp dir")
 	}
@@ -289,7 +288,7 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		}
 
 		glob := []byte(p.Source.Subdir + "/*\n")
-		err = ioutil.WriteFile(filepath.Join(tmpDir, ".git", "info", "sparse-checkout"), glob, 0644)
+		err = os.WriteFile(filepath.Join(tmpDir, ".git", "info", "sparse-checkout"), glob, 0644)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/jsonnetfile/jsonnetfile.go
+++ b/pkg/jsonnetfile/jsonnetfile.go
@@ -16,7 +16,6 @@ package jsonnetfile
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -36,7 +35,7 @@ var (
 
 // Load reads a jsonnetfile.(lock).json from disk
 func Load(filepath string) (v1.JsonnetFile, error) {
-	bytes, err := ioutil.ReadFile(filepath)
+	bytes, err := os.ReadFile(filepath)
 	if err != nil {
 		return v1.New(), err
 	}

--- a/pkg/jsonnetfile/jsonnetfile_test.go
+++ b/pkg/jsonnetfile/jsonnetfile_test.go
@@ -15,7 +15,6 @@
 package jsonnetfile_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -194,14 +193,14 @@ func TestVersions(t *testing.T) {
 }
 
 func TestLoadV1(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "jb-load-jsonnetfile")
+	tempDir, err := os.MkdirTemp("", "jb-load-jsonnetfile")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tempDir)
 
 	tempFile := filepath.Join(tempDir, jsonnetfile.File)
-	err = ioutil.WriteFile(tempFile, []byte(v1JSON), os.ModePerm)
+	err = os.WriteFile(tempFile, []byte(v1JSON), os.ModePerm)
 	assert.Nil(t, err)
 
 	jf, err := jsonnetfile.Load(tempFile)
@@ -210,7 +209,7 @@ func TestLoadV1(t *testing.T) {
 }
 
 func TestLoadEmpty(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "jb-load-empty")
+	tempDir, err := os.MkdirTemp("", "jb-load-empty")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,7 +217,7 @@ func TestLoadEmpty(t *testing.T) {
 
 	// write empty json file
 	tempFile := filepath.Join(tempDir, jsonnetfile.File)
-	err = ioutil.WriteFile(tempFile, []byte(`{}`), os.ModePerm)
+	err = os.WriteFile(tempFile, []byte(`{}`), os.ModePerm)
 	assert.Nil(t, err)
 
 	// expect it to be loaded properly
@@ -240,7 +239,7 @@ func TestFileExists(t *testing.T) {
 		assert.Nil(t, err)
 	}
 	{
-		tempFile, err := ioutil.TempFile("", "jb-exists")
+		tempFile, err := os.CreateTemp("", "jb-exists")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/local_test.go
+++ b/pkg/local_test.go
@@ -16,7 +16,6 @@ package pkg
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,11 +29,11 @@ func TestLocalInstall(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
-	vendorDir, err := ioutil.TempDir(cwd, "vendor")
+	vendorDir, err := os.MkdirTemp(cwd, "vendor")
 	assert.NoError(t, err)
 	defer os.RemoveAll(vendorDir)
 
-	pkgDir, err := ioutil.TempDir(cwd, "foo")
+	pkgDir, err := os.MkdirTemp(cwd, "foo")
 	assert.NoError(t, err)
 	defer os.RemoveAll(pkgDir)
 
@@ -51,7 +50,7 @@ func TestLocalInstallSourceNotFound(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
-	vendorDir, err := ioutil.TempDir(cwd, "vendor")
+	vendorDir, err := os.MkdirTemp(cwd, "vendor")
 	assert.NoError(t, err)
 	defer os.RemoveAll(vendorDir)
 
@@ -66,7 +65,7 @@ func TestLocalInstallTargetDoesNotExist(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
-	pkgDir, err := ioutil.TempDir(cwd, "foo")
+	pkgDir, err := os.MkdirTemp(cwd, "foo")
 	assert.NoError(t, err)
 	defer os.RemoveAll(pkgDir)
 

--- a/spec/v1/deps/dependencies.go
+++ b/spec/v1/deps/dependencies.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/spec/v1/deps/dependencies_test.go
+++ b/spec/v1/deps/dependencies_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/spec/v1/deps/git.go
+++ b/spec/v1/deps/git.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/spec/v1/deps/git_test.go
+++ b/spec/v1/deps/git_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/spec/v1/v0.go
+++ b/spec/v1/v0.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/tool/rewrite/rewrite.go
+++ b/tool/rewrite/rewrite.go
@@ -18,7 +18,6 @@ package rewrite
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -81,13 +80,13 @@ func wrap(s, q string) string {
 }
 
 func replaceFile(name string, imports map[string]string) error {
-	raw, err := ioutil.ReadFile(name)
+	raw, err := os.ReadFile(name)
 	if err != nil {
 		return err
 	}
 
 	out := replace(string(raw), imports)
-	return ioutil.WriteFile(name, out, 0644)
+	return os.WriteFile(name, out, 0644)
 }
 
 func replace(data string, imports map[string]string) []byte {

--- a/tool/rewrite/rewrite_test.go
+++ b/tool/rewrite/rewrite_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,6 @@
 package rewrite
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,12 +59,12 @@ func TestRewriteDeepCustomJsonnetHome(t *testing.T) {
 }
 
 func testRewriteWithJsonnetHome(t *testing.T, jsonnetHome string) {
-	dir, err := ioutil.TempDir("", "jbrewrite")
+	dir, err := os.MkdirTemp("", "jbrewrite")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
 	name := filepath.Join(dir, "test.jsonnet")
-	err = ioutil.WriteFile(name, []byte(sample), 0644)
+	err = os.WriteFile(name, []byte(sample), 0644)
 	require.Nil(t, err)
 
 	vendorDir := filepath.Join(dir, jsonnetHome)
@@ -75,7 +74,7 @@ func testRewriteWithJsonnetHome(t *testing.T, jsonnetHome string) {
 	err = Rewrite(dir, jsonnetHome, locks())
 	require.Nil(t, err)
 
-	content, err := ioutil.ReadFile(name)
+	content, err := os.ReadFile(name)
 	require.Nil(t, err)
 
 	assert.Equal(t, want, string(content))


### PR DESCRIPTION
`ioutil` package is deprecated sinde 1.16 as per https://go.dev/doc/go1.16#ioutil

Also run `go fmt` 