### PR TITLE
feat: parallelized updates/installs

### DIFF
--- a/cmd/jb/install.go
+++ b/cmd/jb/install.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -31,7 +32,7 @@ import (
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
 )
 
-func installCommand(dir, jsonnetHome string, uris []string, single bool, legacyName string) int {
+func installCommand(ctx context.Context, dir, jsonnetHome string, uris []string, single bool, legacyName string) int {
 	if dir == "" {
 		dir = "."
 	}
@@ -83,7 +84,7 @@ func installCommand(dir, jsonnetHome string, uris []string, single bool, legacyN
 	}
 
 	jsonnetPkgHomeDir := filepath.Join(dir, jsonnetHome)
-	locked, err := pkg.Ensure(jsonnetFile, jsonnetPkgHomeDir, lockFile.Dependencies)
+	locked, err := pkg.EnsureContext(ctx, jsonnetFile, jsonnetPkgHomeDir, lockFile.Dependencies)
 	kingpin.FatalIfError(err, "failed to install packages")
 
 	pkg.CleanLegacyName(jsonnetFile.Dependencies)

--- a/cmd/jb/install_test.go
+++ b/cmd/jb/install_test.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -105,7 +106,7 @@ func testInstallCommandWithJsonnetHome(t *testing.T, jsonnetHome string) {
 			jsonnetFileContent(t, jsonnetfile.File, []byte(initContents))
 
 			// install something, check it writes only if required, etc.
-			installCommand("", jsonnetHome, tc.URIs, tc.single, "")
+			installCommand(context.Background(), "", jsonnetHome, tc.URIs, tc.single, "")
 			jsonnetFileContent(t, jsonnetfile.File, tc.ExpectedJsonnetFile)
 			if tc.ExpectedJsonnetLockFile != nil {
 				jsonnetFileContent(t, jsonnetfile.LockFile, tc.ExpectedJsonnetLockFile)
@@ -226,7 +227,7 @@ func TestInstallTransitive(t *testing.T) {
 		subDirB: jsonnetFileWithFrozenLib(frozenLibSecondCommit, ""),
 	})
 
-	require.Equal(t, 0, installCommand(baseDir, "vendor", nil, false, ""))
+	require.Equal(t, 0, installCommand(context.Background(), baseDir, "vendor", nil, false, ""))
 
 	lockCheckFrozenLibVersion(t, filepath.Join(baseDir, "jsonnetfile.lock.json"), frozenLibFirstCommit)
 	require.NoError(t, os.RemoveAll(filepath.Join(baseDir, "jsonnetfile.lock.json")))
@@ -237,7 +238,7 @@ func TestInstallTransitive(t *testing.T) {
 		subDirB: jsonnetFileWithFrozenLib(frozenLibFirstCommit, ""),
 	})
 
-	require.Equal(t, 0, installCommand(baseDir, "vendor", nil, false, ""))
+	require.Equal(t, 0, installCommand(context.Background(), baseDir, "vendor", nil, false, ""))
 
 	lockCheckFrozenLibVersion(t, filepath.Join(baseDir, "jsonnetfile.lock.json"), frozenLibSecondCommit)
 }

--- a/cmd/jb/main.go
+++ b/cmd/jb/main.go
@@ -15,9 +15,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -53,6 +56,8 @@ func Main() int {
 		Default("vendor").StringVar(&cfg.JsonnetHome)
 	a.Flag("quiet", "Suppress any output from git command.").
 		Short('q').BoolVar(&pkg.GitQuiet)
+	a.Flag("jobs", "Maximum number of parallel dependency downloads.").
+		Short('j').Default("10").IntVar(&pkg.Jobs)
 
 	initCmd := a.Command(initActionName, "Initialize a new empty jsonnetfile")
 
@@ -80,17 +85,20 @@ func Main() int {
 
 	cfg.JsonnetHome = filepath.Clean(cfg.JsonnetHome)
 
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	switch command {
 	case initCmd.FullCommand():
 		return initCommand(workdir)
 	case installCmd.FullCommand():
-		return installCommand(workdir, cfg.JsonnetHome, *installCmdURIs, *installCmdSingle, *installCmdLegacyName)
+		return installCommand(ctx, workdir, cfg.JsonnetHome, *installCmdURIs, *installCmdSingle, *installCmdLegacyName)
 	case updateCmd.FullCommand():
-		return updateCommand(workdir, cfg.JsonnetHome, *updateCmdURIs)
+		return updateCommand(ctx, workdir, cfg.JsonnetHome, *updateCmdURIs)
 	case rewriteCmd.FullCommand():
 		return rewriteCommand(workdir, cfg.JsonnetHome)
 	default:
-		installCommand(workdir, cfg.JsonnetHome, []string{}, false, "")
+		installCommand(ctx, workdir, cfg.JsonnetHome, []string{}, false, "")
 	}
 
 	return 0

--- a/cmd/jb/update.go
+++ b/cmd/jb/update.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -26,7 +27,7 @@ import (
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
 )
 
-func updateCommand(dir, jsonnetHome string, uris []string) int {
+func updateCommand(ctx context.Context, dir, jsonnetHome string, uris []string) int {
 	if dir == "" {
 		dir = "."
 	}
@@ -58,7 +59,7 @@ func updateCommand(dir, jsonnetHome string, uris []string) int {
 		locks = deps.NewOrdered()
 	}
 
-	newLocks, err := pkg.Ensure(jsonnetFile, filepath.Join(dir, jsonnetHome), locks)
+	newLocks, err := pkg.EnsureContext(ctx, jsonnetFile, filepath.Join(dir, jsonnetHome), locks)
 	kingpin.FatalIfError(err, "updating")
 
 	kingpin.FatalIfError(

--- a/cmd/jb/update_test.go
+++ b/cmd/jb/update_test.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -89,7 +90,7 @@ func (u UpdateCase) Run(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	ret := updateCommand(dir, "vendor", u.uris)
+	ret := updateCommand(context.Background(), dir, "vendor", u.uris)
 	assert.Equal(t, ret, 0)
 
 	if u.after != nil {

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -50,37 +50,24 @@ func NewGitPackage(source *deps.Git) Interface {
 
 var GitQuiet = false
 
-func downloadGitHubArchive(ctx context.Context, filepath string, url string) error {
+func downloadGitHubArchive(ctx context.Context, url string) (io.ReadCloser, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer resp.Body.Close()
 	if !GitQuiet {
 		color.Cyan("GET %s %d", url, resp.StatusCode)
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+		resp.Body.Close()
+		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 
-	// Create the file
-	out, err := os.Create(filepath)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	// Write the body to file
-	_, err = io.Copy(out, resp.Body)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return resp.Body, nil
 }
 
 func gzipUntar(dst string, r io.Reader, subDir string) error {
@@ -208,27 +195,24 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		}
 
 		archiveUrl := fmt.Sprintf("%s/archive/%s.tar.gz", strings.TrimSuffix(p.Source.Remote(), ".git"), commitSha)
-		archiveFilepath := fmt.Sprintf("%s.tar.gz", tmpDir)
 
-		defer os.Remove(archiveFilepath)
-		err = downloadGitHubArchive(ctx, archiveFilepath, archiveUrl)
+		var ar io.ReadCloser
+		ar, err = downloadGitHubArchive(ctx, archiveUrl)
 		if err == nil {
-			var ar *os.File
-			ar, err = os.Open(archiveFilepath)
-			defer ar.Close()
-			if err == nil {
-				// Extract the sub-directory (if any) from the archive
-				// If none specified, the entire archive is unpacked
-				err = gzipUntar(tmpDir, ar, p.Source.Subdir)
+			// Extract the sub-directory (if any) from the archive.
+			// If none specified, the entire archive is unpacked.
+			err = gzipUntar(tmpDir, ar, p.Source.Subdir)
+			if closeErr := ar.Close(); err == nil {
+				err = closeErr
+			}
 
-				// Move the extracted directory to its final destination
-				if err == nil {
-					if err := os.MkdirAll(filepath.Dir(destPath), os.ModePerm); err != nil {
-						panic(err)
-					}
-					if err := os.Rename(path.Join(tmpDir, p.Source.Subdir), destPath); err != nil {
-						panic(err)
-					}
+			// Move the extracted directory to its final destination.
+			if err == nil {
+				if err := os.MkdirAll(filepath.Dir(destPath), os.ModePerm); err != nil {
+					panic(err)
+				}
+				if err := os.Rename(path.Join(tmpDir, p.Source.Subdir), destPath); err != nil {
+					panic(err)
 				}
 			}
 		}

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -50,20 +50,22 @@ func NewGitPackage(source *deps.Git) Interface {
 
 var GitQuiet = false
 
-func downloadGitHubArchive(filepath string, url string) error {
-	// Get the data
-	resp, err := http.Get(url)
+func downloadGitHubArchive(ctx context.Context, filepath string, url string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
 	if !GitQuiet {
 		color.Cyan("GET %s %d", url, resp.StatusCode)
 	}
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
-
-	defer resp.Body.Close()
 
 	// Create the file
 	out, err := os.Create(filepath)
@@ -209,7 +211,7 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 		archiveFilepath := fmt.Sprintf("%s.tar.gz", tmpDir)
 
 		defer os.Remove(archiveFilepath)
-		err = downloadGitHubArchive(archiveFilepath, archiveUrl)
+		err = downloadGitHubArchive(ctx, archiveFilepath, archiveUrl)
 		if err == nil {
 			var ar *os.File
 			ar, err = os.Open(archiveFilepath)
@@ -233,6 +235,9 @@ func (p *GitPackage) Install(ctx context.Context, name, dir, version string) (st
 
 		if err == nil {
 			return commitSha, nil
+		}
+		if ctx.Err() != nil {
+			return "", ctx.Err()
 		}
 
 		// The repository may be private or the archive download may not work

--- a/pkg/packages.go
+++ b/pkg/packages.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -35,6 +37,18 @@ import (
 var (
 	VersionMismatch = errors.New("multiple colliding versions specified")
 )
+
+// Jobs controls the maximum number of dependencies downloaded in parallel
+// at each level of the dependency tree. Values < 1 are treated as 1.
+var Jobs = 10
+
+// downloadAttempts is the total number of attempts (1 + retries) for a
+// single git-source download. Local sources are not retried.
+const downloadAttempts = 3
+
+// downloadInitialBackoff is the wait before the second attempt; each
+// subsequent retry doubles the wait. It is a var so tests can shorten it.
+var downloadInitialBackoff = time.Second
 
 // Ensure receives all direct packages, the directory to vendor into and all known locks.
 // It then makes sure all direct and nested dependencies are present in vendor at the correct version:
@@ -50,9 +64,17 @@ var (
 // Finally, all unknown files and directories are removed from vendor/
 // The full list of locked depedencies is returned
 func Ensure(direct v1.JsonnetFile, vendorDir string, oldLocks *deps.Ordered) (*deps.Ordered, error) {
+	return EnsureContext(context.Background(), direct, vendorDir, oldLocks)
+}
+
+// EnsureContext is the cancellation-aware variant of Ensure. When ctx is
+// cancelled, in-flight downloads are interrupted (the underlying git
+// processes and HTTP requests are torn down) and the function returns
+// promptly with the cancellation error.
+func EnsureContext(ctx context.Context, direct v1.JsonnetFile, vendorDir string, oldLocks *deps.Ordered) (*deps.Ordered, error) {
 	// ensure all required files are in vendor
 	// This is the actual installation
-	locks, err := ensure(direct.Dependencies, vendorDir, "", oldLocks)
+	locks, err := ensure(ctx, direct.Dependencies, vendorDir, "", oldLocks)
 	if err != nil {
 		return nil, err
 	}
@@ -214,42 +236,118 @@ func known(deps *deps.Ordered, p string) bool {
 	return false
 }
 
-func ensure(direct *deps.Ordered, vendorDir, pathToParentModule string, locks *deps.Ordered) (*deps.Ordered, error) {
-	deps := deps.NewOrdered()
+func ensure(ctx context.Context, direct *deps.Ordered, vendorDir, pathToParentModule string, locks *deps.Ordered) (*deps.Ordered, error) {
+	out := deps.NewOrdered()
 
-	for _, k := range direct.Keys() {
+	type job struct {
+		idx         int
+		dep         deps.Dependency
+		expectedSum string
+	}
+
+	keys := direct.Keys()
+	results := make([]*deps.Dependency, len(keys))
+	var jobs []job
+
+	// Resolve the locked-and-intact entries up front; queue the rest for
+	// parallel download.
+	for i, k := range keys {
 		d, _ := direct.Get(k)
 		l, present := locks.Get(d.Name())
 
-		// already locked and the integrity is intact
 		if present {
 			d.Version = l.Version
 
 			if check(l, vendorDir) {
-				deps.Set(d.Name(), l)
+				locked := l
+				results[i] = &locked
 				continue
 			}
 		}
 		expectedSum := l.Sum
 
-		// either not present or not intact: download again
 		dir := filepath.Join(vendorDir, d.Name())
 		os.RemoveAll(dir)
 
-		locked, err := download(d, vendorDir, pathToParentModule)
-		if err != nil {
-			return nil, errors.Wrap(err, "downloading")
-		}
-		if expectedSum != "" && locked.Sum != expectedSum {
-			return nil, fmt.Errorf("checksum mismatch for %s. Expected %s but got %s", d.Name(), expectedSum, locked.Sum)
-		}
-		deps.Set(d.Name(), *locked)
-		// we settled on a new version, add it to the locks for recursion
-		locks.Set(d.Name(), *locked)
+		jobs = append(jobs, job{idx: i, dep: d, expectedSum: expectedSum})
 	}
 
-	for _, k := range deps.Keys() {
-		d, _ := deps.Get(k)
+	if len(jobs) > 0 {
+		maxJobs := Jobs
+		if maxJobs < 1 {
+			maxJobs = 1
+		}
+		if maxJobs > len(jobs) {
+			maxJobs = len(jobs)
+		}
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		var wg sync.WaitGroup
+		var locksMu sync.Mutex
+		errCh := make(chan error, 1)
+		setErr := func(err error) {
+			select {
+			case errCh <- err:
+				cancel()
+			default:
+			}
+		}
+
+		jobCh := make(chan job, len(jobs))
+		for _, j := range jobs {
+			jobCh <- j
+		}
+		close(jobCh)
+
+		for i := 0; i < maxJobs; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				for j := range jobCh {
+					if err := ctx.Err(); err != nil {
+						setErr(err)
+						return
+					}
+
+					locked, err := download(ctx, j.dep, vendorDir, pathToParentModule)
+					if err != nil {
+						setErr(errors.Wrap(err, "downloading"))
+						return
+					}
+					if j.expectedSum != "" && locked.Sum != j.expectedSum {
+						setErr(fmt.Errorf("checksum mismatch for %s. Expected %s but got %s", j.dep.Name(), j.expectedSum, locked.Sum))
+						return
+					}
+
+					locksMu.Lock()
+					locks.Set(j.dep.Name(), *locked)
+					locksMu.Unlock()
+
+					results[j.idx] = locked
+				}
+			}()
+		}
+		wg.Wait()
+		select {
+		case err := <-errCh:
+			return nil, err
+		default:
+		}
+	}
+
+	// Preserve input dependency order.
+	for _, dep := range results {
+		if dep == nil {
+			continue
+		}
+		out.Set(dep.Name(), *dep)
+	}
+
+	for _, k := range out.Keys() {
+		d, _ := out.Get(k)
 		if d.Single {
 			// skip dependencies that explicitely don't want nested ones installed
 			continue
@@ -268,29 +366,32 @@ func ensure(direct *deps.Ordered, vendorDir, pathToParentModule string, locks *d
 			return nil, err
 		}
 
-		nested, err := ensure(f.Dependencies, vendorDir, absolutePath, locks)
+		nested, err := ensure(ctx, f.Dependencies, vendorDir, absolutePath, locks)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, k := range nested.Keys() {
 			d, _ := nested.Get(k)
-			if _, ok := deps.Get(d.Name()); !ok {
-				deps.Set(d.Name(), d)
+			if _, ok := out.Get(d.Name()); !ok {
+				out.Set(d.Name(), d)
 			}
 		}
 	}
 
-	return deps, nil
+	return out, nil
 }
 
 // download retrieves a package from a remote upstream. The checksum of the
-// files is generated afterwards.
-func download(d deps.Dependency, vendorDir, pathToParentModule string) (*deps.Dependency, error) {
+// files is generated afterwards. ctx is forwarded to git and HTTP calls so
+// the caller can cancel work in flight.
+func download(ctx context.Context, d deps.Dependency, vendorDir, pathToParentModule string) (*deps.Dependency, error) {
 	var p Interface
+	isGit := false
 	switch {
 	case d.Source.GitSource != nil:
 		p = NewGitPackage(d.Source.GitSource)
+		isGit = true
 	case d.Source.LocalSource != nil:
 		wd, err := os.Getwd()
 		if err != nil {
@@ -313,7 +414,13 @@ func download(d deps.Dependency, vendorDir, pathToParentModule string) (*deps.De
 		return nil, errors.New("either git or local source is required")
 	}
 
-	version, err := p.Install(context.TODO(), d.Name(), vendorDir, d.Version)
+	var version string
+	var err error
+	if isGit {
+		version, err = installWithRetry(ctx, p, d.Name(), vendorDir, d.Version)
+	} else {
+		version, err = p.Install(ctx, d.Name(), vendorDir, d.Version)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -326,6 +433,35 @@ func download(d deps.Dependency, vendorDir, pathToParentModule string) (*deps.De
 	d.Version = version
 	d.Sum = sum
 	return &d, nil
+}
+
+// installWithRetry calls p.Install up to downloadAttempts times, waiting
+// with exponential backoff between attempts. It returns immediately on
+// success or when ctx is cancelled.
+func installWithRetry(ctx context.Context, p Interface, name, vendorDir, version string) (string, error) {
+	var lastErr error
+	backoff := downloadInitialBackoff
+	for attempt := 1; attempt <= downloadAttempts; attempt++ {
+		v, err := p.Install(ctx, name, vendorDir, version)
+		if err == nil {
+			return v, nil
+		}
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		lastErr = err
+		if attempt == downloadAttempts {
+			break
+		}
+		color.Yellow("retry %d/%d for %s after %s: %v", attempt, downloadAttempts-1, name, backoff, err)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+		backoff *= 2
+	}
+	return "", lastErr
 }
 
 // check returns whether the files present at the vendor/ folder match the

--- a/pkg/packages_test.go
+++ b/pkg/packages_test.go
@@ -15,10 +15,33 @@
 package pkg
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/jsonnet-bundler/jsonnet-bundler/spec/v1"
 	"github.com/jsonnet-bundler/jsonnet-bundler/spec/v1/deps"
 )
+
+// flakyInstaller fails its first failTimes Install calls then succeeds.
+type flakyInstaller struct {
+	failTimes int
+	calls     int
+}
+
+func (f *flakyInstaller) Install(ctx context.Context, name, dir, version string) (string, error) {
+	f.calls++
+	if f.calls <= f.failTimes {
+		return "", errors.New("flake")
+	}
+	return "ok", nil
+}
 
 func TestKnown(t *testing.T) {
 	testDeps := deps.NewOrdered()
@@ -63,6 +86,144 @@ func TestKnown(t *testing.T) {
 			t.Fatalf("expected %s to be %v", p, w[p])
 		}
 	}
+}
+
+func TestInstallWithRetry(t *testing.T) {
+	orig := downloadInitialBackoff
+	t.Cleanup(func() { downloadInitialBackoff = orig })
+	downloadInitialBackoff = time.Millisecond
+
+	t.Run("first try succeeds", func(t *testing.T) {
+		f := &flakyInstaller{failTimes: 0}
+		v, err := installWithRetry(context.Background(), f, "x", "y", "z")
+		require.NoError(t, err)
+		require.Equal(t, "ok", v)
+		require.Equal(t, 1, f.calls)
+	})
+
+	t.Run("eventual success retries", func(t *testing.T) {
+		f := &flakyInstaller{failTimes: 1}
+		_, err := installWithRetry(context.Background(), f, "x", "y", "z")
+		require.NoError(t, err)
+		require.Equal(t, 2, f.calls, "should retry once")
+	})
+
+	t.Run("gives up after max attempts", func(t *testing.T) {
+		f := &flakyInstaller{failTimes: 99}
+		_, err := installWithRetry(context.Background(), f, "x", "y", "z")
+		require.Error(t, err)
+		require.Equal(t, downloadAttempts, f.calls)
+	})
+
+	t.Run("cancelled ctx returns immediately", func(t *testing.T) {
+		f := &flakyInstaller{failTimes: 99}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := installWithRetry(ctx, f, "x", "y", "z")
+		require.ErrorIs(t, err, context.Canceled)
+		// First Install runs once before the ctx check; the loop must
+		// not keep retrying after that.
+		require.LessOrEqual(t, f.calls, 1)
+	})
+}
+
+// TestEnsureParallel verifies that Ensure handles many dependencies in
+// parallel without losing input order, regardless of the Jobs setting. It
+// uses local-source dependencies so no network is required, and relies on
+// the race detector (run via `go test -race`) to catch concurrent map writes.
+func TestEnsureParallel(t *testing.T) {
+	for _, jobs := range []int{1, 4, 25, 100} {
+		t.Run(fmt.Sprintf("jobs=%d", jobs), func(t *testing.T) {
+			origCwd, err := os.Getwd()
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.Chdir(origCwd) })
+
+			origJobs := Jobs
+			t.Cleanup(func() { Jobs = origJobs })
+			Jobs = jobs
+
+			base := t.TempDir()
+			require.NoError(t, os.Chdir(base))
+
+			vendorDir := filepath.Join(base, "vendor")
+			require.NoError(t, os.MkdirAll(filepath.Join(vendorDir, ".tmp"), 0755))
+
+			const N = 25
+			direct := deps.NewOrdered()
+			expectedOrder := make([]string, 0, N)
+			for i := 0; i < N; i++ {
+				name := fmt.Sprintf("pkg-%02d", i)
+				require.NoError(t, os.Mkdir(filepath.Join(base, name), 0755))
+				d := deps.Dependency{
+					Source: deps.Source{
+						LocalSource: &deps.Local{Directory: name},
+					},
+				}
+				direct.Set(d.Name(), d)
+				expectedOrder = append(expectedOrder, d.Name())
+			}
+
+			locked, err := Ensure(
+				v1.JsonnetFile{Dependencies: direct, LegacyImports: false},
+				vendorDir,
+				deps.NewOrdered(),
+			)
+			require.NoError(t, err)
+			require.Equal(t, expectedOrder, locked.Keys(),
+				"parallel ensure must preserve input dependency order")
+
+			for _, name := range expectedOrder {
+				info, err := os.Lstat(filepath.Join(vendorDir, name))
+				require.NoError(t, err, "missing entry for %s", name)
+				require.NotZero(t, info.Mode()&os.ModeSymlink,
+					"%s should be a symlink", name)
+			}
+		})
+	}
+}
+
+// TestEnsureParallelError verifies that a failure in one parallel download
+// surfaces as a non-nil error from Ensure rather than hanging or panicking.
+func TestEnsureParallelError(t *testing.T) {
+	origCwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(origCwd) })
+
+	origJobs := Jobs
+	t.Cleanup(func() { Jobs = origJobs })
+	Jobs = 4
+
+	base := t.TempDir()
+	require.NoError(t, os.Chdir(base))
+
+	vendorDir := filepath.Join(base, "vendor")
+	require.NoError(t, os.MkdirAll(filepath.Join(vendorDir, ".tmp"), 0755))
+
+	direct := deps.NewOrdered()
+	bad := deps.Dependency{
+		Source: deps.Source{
+			LocalSource: &deps.Local{Directory: "does-not-exist"},
+		},
+	}
+	direct.Set(bad.Name(), bad)
+
+	for i := 0; i < 3; i++ {
+		name := fmt.Sprintf("good-%d", i)
+		require.NoError(t, os.Mkdir(filepath.Join(base, name), 0755))
+		d := deps.Dependency{
+			Source: deps.Source{
+				LocalSource: &deps.Local{Directory: name},
+			},
+		}
+		direct.Set(d.Name(), d)
+	}
+
+	_, err = Ensure(
+		v1.JsonnetFile{Dependencies: direct, LegacyImports: false},
+		vendorDir,
+		deps.NewOrdered(),
+	)
+	require.Error(t, err)
 }
 
 func TestCleanLegacyName(t *testing.T) {


### PR DESCRIPTION
`jb update  7.30s user 2.30s system 9% cpu 1:40.38 total`

vs

`~/oss/jsonnet-bundler/_output/jb update  14.00s user 1.84s system 66% cpu 23.958 total`